### PR TITLE
Upgrade slurm-operator fork to Slinky v1.0 with Together-specific features

### DIFF
--- a/PROJECT
+++ b/PROJECT
@@ -9,7 +9,7 @@ plugins:
   manifests.sdk.operatorframework.io/v2: {}
   scorecard.sdk.operatorframework.io/v2: {}
 projectName: slurm-operator
-repo: github.com/SlinkyProject/slurm-operator
+repo: github.com/togethercomputer/slurm-operator
 resources:
 - api:
     crdVersion: v1beta1
@@ -18,7 +18,7 @@ resources:
   domain: slurm.net
   group: slinky
   kind: Controller
-  path: github.com/SlinkyProject/slurm-operator/api/v1beta1
+  path: github.com/togethercomputer/slurm-operator/api/v1beta1
   version: v1beta1
   webhooks:
     validation: true
@@ -30,7 +30,7 @@ resources:
   domain: slurm.net
   group: slinky
   kind: RestApi
-  path: github.com/SlinkyProject/slurm-operator/api/v1beta1
+  path: github.com/togethercomputer/slurm-operator/api/v1beta1
   version: v1beta1
   webhooks:
     validation: true
@@ -42,7 +42,7 @@ resources:
   domain: slurm.net
   group: slinky
   kind: Accounting
-  path: github.com/SlinkyProject/slurm-operator/api/v1beta1
+  path: github.com/togethercomputer/slurm-operator/api/v1beta1
   version: v1beta1
   webhooks:
     validation: true
@@ -54,7 +54,7 @@ resources:
   domain: slurm.net
   group: slinky
   kind: NodeSet
-  path: github.com/SlinkyProject/slurm-operator/api/v1beta1
+  path: github.com/togethercomputer/slurm-operator/api/v1beta1
   version: v1beta1
   webhooks:
     validation: true
@@ -66,7 +66,7 @@ resources:
   domain: slurm.net
   group: slinky
   kind: LoginSet
-  path: github.com/SlinkyProject/slurm-operator/api/v1beta1
+  path: github.com/togethercomputer/slurm-operator/api/v1beta1
   version: v1beta1
   webhooks:
     validation: true
@@ -78,7 +78,7 @@ resources:
   domain: slurm.net
   group: slinky
   kind: Token
-  path: github.com/SlinkyProject/slurm-operator/api/v1beta1
+  path: github.com/togethercomputer/slurm-operator/api/v1beta1
   version: v1beta1
   webhooks:
     validation: true
@@ -90,6 +90,6 @@ resources:
   domain: slurm.net
   group: slinky
   kind: Controller
-  path: github.com/SlinkyProject/slurm-operator/api/v1beta1
+  path: github.com/togethercomputer/slurm-operator/api/v1beta1
   version: v1beta1
 version: "3"

--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@
 <div align="center">
 
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg?style=for-the-badge)](./LICENSES/Apache-2.0.txt)
-[![Tag](https://img.shields.io/github/v/tag/SlinkyProject/slurm-operator?style=for-the-badge)](https://github.com/SlinkyProject/slurm-operator/tags/)
-[![Go-Version](https://img.shields.io/github/go-mod/go-version/SlinkyProject/slurm-operator?style=for-the-badge)](./go.mod)
-[![Last-Commit](https://img.shields.io/github/last-commit/SlinkyProject/slurm-operator?style=for-the-badge)](https://github.com/SlinkyProject/slurm-operator/commits/)
+[![Tag](https://img.shields.io/github/v/tag/togethercomputer/slurm-operator?style=for-the-badge)](https://github.com/togethercomputer/slurm-operator/tags/)
+[![Go-Version](https://img.shields.io/github/go-mod/go-version/togethercomputer/slurm-operator?style=for-the-badge)](./go.mod)
+[![Last-Commit](https://img.shields.io/github/last-commit/togethercomputer/slurm-operator?style=for-the-badge)](https://github.com/togethercomputer/slurm-operator/commits/)
 
 </div>
 

--- a/api/v1beta1/accounting_keys.go
+++ b/api/v1beta1/accounting_keys.go
@@ -9,7 +9,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 
-	"github.com/SlinkyProject/slurm-operator/internal/utils/domainname"
+	"github.com/togethercomputer/slurm-operator/internal/utils/domainname"
 )
 
 func (o *Accounting) Key() types.NamespacedName {

--- a/api/v1beta1/controller_keys.go
+++ b/api/v1beta1/controller_keys.go
@@ -9,7 +9,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 
-	"github.com/SlinkyProject/slurm-operator/internal/utils/domainname"
+	"github.com/togethercomputer/slurm-operator/internal/utils/domainname"
 )
 
 func (o *Controller) ClusterName() string {

--- a/api/v1beta1/loginset_keys.go
+++ b/api/v1beta1/loginset_keys.go
@@ -9,7 +9,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 
-	"github.com/SlinkyProject/slurm-operator/internal/utils/domainname"
+	"github.com/togethercomputer/slurm-operator/internal/utils/domainname"
 )
 
 func (o *LoginSet) Key() types.NamespacedName {

--- a/api/v1beta1/restapi_keys.go
+++ b/api/v1beta1/restapi_keys.go
@@ -8,7 +8,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/types"
 
-	"github.com/SlinkyProject/slurm-operator/internal/utils/domainname"
+	"github.com/togethercomputer/slurm-operator/internal/utils/domainname"
 )
 
 func (o *RestApi) Key() types.NamespacedName {

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -23,15 +23,15 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	"sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
-	slinkyv1beta1 "github.com/SlinkyProject/slurm-operator/api/v1beta1"
-	"github.com/SlinkyProject/slurm-operator/internal/clientmap"
-	"github.com/SlinkyProject/slurm-operator/internal/controller/accounting"
-	"github.com/SlinkyProject/slurm-operator/internal/controller/controller"
-	"github.com/SlinkyProject/slurm-operator/internal/controller/loginset"
-	"github.com/SlinkyProject/slurm-operator/internal/controller/nodeset"
-	"github.com/SlinkyProject/slurm-operator/internal/controller/restapi"
-	"github.com/SlinkyProject/slurm-operator/internal/controller/slurmclient"
-	"github.com/SlinkyProject/slurm-operator/internal/controller/token"
+	slinkyv1beta1 "github.com/togethercomputer/slurm-operator/api/v1beta1"
+	"github.com/togethercomputer/slurm-operator/internal/clientmap"
+	"github.com/togethercomputer/slurm-operator/internal/controller/accounting"
+	"github.com/togethercomputer/slurm-operator/internal/controller/controller"
+	"github.com/togethercomputer/slurm-operator/internal/controller/loginset"
+	"github.com/togethercomputer/slurm-operator/internal/controller/nodeset"
+	"github.com/togethercomputer/slurm-operator/internal/controller/restapi"
+	"github.com/togethercomputer/slurm-operator/internal/controller/slurmclient"
+	"github.com/togethercomputer/slurm-operator/internal/controller/token"
 	// +kubebuilder:scaffold:imports
 )
 

--- a/cmd/webhook/main.go
+++ b/cmd/webhook/main.go
@@ -22,8 +22,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/metrics/server"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 
-	slinkyv1beta1 "github.com/SlinkyProject/slurm-operator/api/v1beta1"
-	slinkywebhook "github.com/SlinkyProject/slurm-operator/internal/webhook"
+	slinkyv1beta1 "github.com/togethercomputer/slurm-operator/api/v1beta1"
+	slinkywebhook "github.com/togethercomputer/slurm-operator/internal/webhook"
 	// +kubebuilder:scaffold:imports
 )
 

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -22,15 +22,15 @@ target "_common" {
   labels = {
     # Ref: https://github.com/opencontainers/image-spec/blob/v1.0/annotations.md
     "org.opencontainers.image.authors" = "slinky@schedmd.com"
-    "org.opencontainers.image.documentation" = "https://github.com/SlinkyProject/slurm-operator"
+    "org.opencontainers.image.documentation" = "https://github.com/togethercomputer/slurm-operator"
     "org.opencontainers.image.license" = "Apache-2.0"
     "org.opencontainers.image.vendor" = "SchedMD LLC."
     "org.opencontainers.image.version" = "${VERSION}"
-    "org.opencontainers.image.source" = "https://github.com/SlinkyProject/slurm-operator"
+    "org.opencontainers.image.source" = "https://github.com/togethercomputer/slurm-operator"
     # Ref: https://docs.redhat.com/en/documentation/red_hat_software_certification/2025/html/red_hat_openshift_software_certification_policy_guide/assembly-requirements-for-container-images_openshift-sw-cert-policy-introduction#con-image-metadata-requirements_openshift-sw-cert-policy-container-images
     "vendor" = "SchedMD LLC."
     "version" = "${VERSION}"
-    "release" = "https://github.com/SlinkyProject/slurm-operator"
+    "release" = "https://github.com/togethercomputer/slurm-operator"
   }
 }
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -345,12 +345,12 @@ limitations under the License.
 
 .. |License| image:: https://img.shields.io/badge/License-Apache_2.0-blue.svg?style=for-the-badge
    :target: ./LICENSES/Apache-2.0.txt
-.. |Tag| image:: https://img.shields.io/github/v/tag/SlinkyProject/slurm-operator?style=for-the-badge
-   :target: https://github.com/SlinkyProject/slurm-operator/tags/
-.. |Go-Version| image:: https://img.shields.io/github/go-mod/go-version/SlinkyProject/slurm-operator?style=for-the-badge
+.. |Tag| image:: https://img.shields.io/github/v/tag/togethercomputer/slurm-operator?style=for-the-badge
+   :target: https://github.com/togethercomputer/slurm-operator/tags/
+.. |Go-Version| image:: https://img.shields.io/github/go-mod/go-version/togethercomputer/slurm-operator?style=for-the-badge
    :target: ./go.mod
-.. |Last-Commit| image:: https://img.shields.io/github/last-commit/SlinkyProject/slurm-operator?style=for-the-badge
-   :target: https://github.com/SlinkyProject/slurm-operator/commits/
+.. |Last-Commit| image:: https://img.shields.io/github/last-commit/togethercomputer/slurm-operator?style=for-the-badge
+   :target: https://github.com/togethercomputer/slurm-operator/commits/
 
 .. toctree::
     :maxdepth: 2

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -58,4 +58,4 @@ any kind (e.g., component flag changes).
 [semver]: https://semver.org/
 [slurm-bridge]: https://github.com/SlinkyProject/slurm-bridge
 [slurm-client]: https://github.com/SlinkyProject/slurm-client
-[slurm-operator]: https://github.com/SlinkyProject/slurm-operator
+[slurm-operator]: https://github.com/togethercomputer/slurm-operator

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/SlinkyProject/slurm-operator
+module github.com/togethercomputer/slurm-operator
 
 go 1.25.0
 

--- a/helm/slurm-operator-crds/Chart.yaml
+++ b/helm/slurm-operator-crds/Chart.yaml
@@ -13,7 +13,7 @@ home: https://slinky.schedmd.com/
 icon: https://github.com/SlinkyProject/docs/blob/main/docs/_static/images/slinky.svg
 
 sources:
-  - https://github.com/SlinkyProject/slurm-operator
+  - https://github.com/togethercomputer/slurm-operator
 
 maintainers:
   - name: SchedMD LLC.

--- a/helm/slurm-operator-crds/README.md
+++ b/helm/slurm-operator-crds/README.md
@@ -14,5 +14,5 @@ Slurm Operator CRDs
 
 ## Source Code
 
-* <https://github.com/SlinkyProject/slurm-operator>
+* <https://github.com/togethercomputer/slurm-operator>
 

--- a/helm/slurm-operator/Chart.yaml
+++ b/helm/slurm-operator/Chart.yaml
@@ -15,7 +15,7 @@ home: https://slinky.schedmd.com/
 icon: https://github.com/SlinkyProject/docs/blob/main/docs/_static/images/slinky.svg
 
 sources:
-  - https://github.com/SlinkyProject/slurm-operator
+  - https://github.com/togethercomputer/slurm-operator
 
 maintainers:
   - name: SchedMD LLC.

--- a/helm/slurm-operator/README.md
+++ b/helm/slurm-operator/README.md
@@ -14,7 +14,7 @@ Slurm Operator
 
 ## Source Code
 
-* <https://github.com/SlinkyProject/slurm-operator>
+* <https://github.com/togethercomputer/slurm-operator>
 
 ## Requirements
 

--- a/helm/slurm-operator/templates/operator/rbac.yaml
+++ b/helm/slurm-operator/templates/operator/rbac.yaml
@@ -45,6 +45,7 @@ rules:
   - list
   - watch
   - patch
+  - update
 - apiGroups:
   - ""
   resources:

--- a/helm/slurm/Chart.yaml
+++ b/helm/slurm/Chart.yaml
@@ -17,7 +17,7 @@ icon: https://github.com/SlinkyProject/docs/blob/main/docs/_static/images/slurm-
 sources:
   - https://github.com/SchedMD/slurm
   - https://github.com/SlinkyProject/containers
-  - https://github.com/SlinkyProject/slurm-operator
+  - https://github.com/togethercomputer/slurm-operator
 
 maintainers:
   - name: SchedMD LLC.

--- a/helm/slurm/README.md
+++ b/helm/slurm/README.md
@@ -16,7 +16,7 @@ Slurm Cluster
 
 * <https://github.com/SchedMD/slurm>
 * <https://github.com/SlinkyProject/containers>
-* <https://github.com/SlinkyProject/slurm-operator>
+* <https://github.com/togethercomputer/slurm-operator>
 
 ## Requirements
 

--- a/helm/slurm/templates/_slurm.tpl
+++ b/helm/slurm/templates/_slurm.tpl
@@ -30,3 +30,27 @@ Define auth/jwt HS256 secret ref key
 {{- define "slurm.authJwtHs256Ref.key" -}}
 {{- print "jwt_hs256.key" -}}
 {{- end }}
+
+{{/*
+Define login name
+*/}}
+{{- define "slurm.login.name" -}}
+{{- printf "%s-login" (include "slurm.fullname" .) -}}
+{{- end }}
+
+{{/*
+Define login labels
+*/}}
+{{- define "slurm.login.labels" -}}
+app.kubernetes.io/component: login
+{{ include "slurm.login.selectorLabels" . }}
+{{ include "slurm.labels" . }}
+{{- end }}
+
+{{/*
+Define login selectorLabels
+*/}}
+{{- define "slurm.login.selectorLabels" -}}
+app.kubernetes.io/name: login
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/helm/slurm/templates/controller/controller-cr.yaml
+++ b/helm/slurm/templates/controller/controller-cr.yaml
@@ -97,14 +97,14 @@ spec:
   {{- include "format-podTemplate" $podTemplate | nindent 2 }}
   persistence:
     {{- with .Values.controller.persistence.existingClaim }}
-    {{- toYaml . | nindent 4 }}
+    existingClaim: {{ toYaml . | nindent 6 | trim }}
     {{- end }}{{- /* with .Values.controller.persistence.existingClaim */}}
     {{- with .Values.controller.persistence.storageClassName }}
-    {{- toYaml . | nindent 4 }}
+    storageClassName: {{ . }}
     {{- end }}{{- /* with .Values.controller.persistence.storageClassName */}}
-    {{- with omit .Values.controller.persistence "existingClaim" "storageClassName"}}
+    {{- with omit .Values.controller.persistence "existingClaim" "storageClassName" "enabled"}}
     {{- toYaml . | nindent 4 }}
-    {{- end }}{{- /* with omit .Values.controller.persistence "existingClaim" "storageClassName" */}}
+    {{- end }}{{- /* with omit .Values.controller.persistence "existingClaim" "storageClassName" "enabled" */}}
   {{- if or (.Values.controller.service.spec) (.Values.controller.service.metadata) (omit .Values.controller.service  "metadata" "spec") }}
   {{- include "format-service" .Values.controller.service | nindent 2 }}
   {{ else }}

--- a/helm/slurm/templates/login/login-deployment.yaml
+++ b/helm/slurm/templates/login/login-deployment.yaml
@@ -1,0 +1,138 @@
+{{- /*
+SPDX-FileCopyrightText: Copyright (C) SchedMD LLC.
+SPDX-License-Identifier: Apache-2.0
+*/}}
+
+{{- if .Values.login.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "slurm.login.name" . }}
+  namespace: {{ include "slurm.namespace" . }}
+  labels:
+    {{- include "slurm.login.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.login.replicas }}
+  selector:
+    matchLabels:
+      {{- include "slurm.login.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "slurm.login.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.login.priorityClassName }}
+      priorityClassName: {{ . }}
+      {{- end }}
+      {{- with .Values.login.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.login.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.login.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+      - name: login
+        image: "{{ .Values.login.image.repository }}:{{ .Values.login.image.tag }}"
+        imagePullPolicy: {{ .Values.login.imagePullPolicy | default .Values.imagePullPolicy }}
+        {{- with .Values.login.securityContext }}
+        securityContext:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+        {{- with .Values.login.resources }}
+        resources:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+        env:
+        - name: SLURM_CLUSTER_NAME
+          value: {{ include "slurm.fullname" . }}
+        - name: SLURM_CONF_SERVER
+          value: {{ include "slurm.fullname" . }}.{{ include "slurm.namespace" . }}.svc.cluster.local
+        volumeMounts:
+        - name: slurm-config
+          mountPath: /etc/slurm
+        {{- if .Values.login.sharedMemorySize }}
+        - name: dshm
+          mountPath: /dev/shm
+        {{- end }}
+        {{- range .Values.login.extraVolumeMounts }}
+        - name: {{ .name }}
+          mountPath: {{ .mountPath }}
+          {{- if .subPath }}
+          subPath: {{ .subPath }}
+          {{- end }}
+          {{- if .readOnly }}
+          readOnly: {{ .readOnly }}
+          {{- end }}
+        {{- end }}
+        command: ["/bin/bash", "-c"]
+        args:
+        - |
+          set -e
+          echo "Starting login node..."
+          # Wait for slurm.conf to be available
+          while [ ! -f /etc/slurm/slurm.conf ]; do
+            echo "Waiting for slurm.conf..."
+            sleep 5
+          done
+          # Start munge
+          service munge start
+          # Start SSH service if needed
+          if command -v sshd &> /dev/null; then
+            service ssh start || service sshd start || true
+          fi
+          # Keep container running
+          tail -f /dev/null
+      volumes:
+      - name: slurm-config
+        configMap:
+          name: {{ include "slurm.fullname" . }}-config
+      {{- if .Values.login.sharedMemorySize }}
+      - name: dshm
+        emptyDir:
+          medium: Memory
+          sizeLimit: {{ .Values.login.sharedMemorySize }}
+      {{- end }}
+      {{- range .Values.login.extraVolumes }}
+      - name: {{ .name }}
+        {{- if .configMap }}
+        configMap:
+          name: {{ .configMap.name }}
+          {{- with .configMap.items }}
+          items:
+            {{- toYaml . | nindent 10 }}
+          {{- end }}
+        {{- else if .secret }}
+        secret:
+          secretName: {{ .secret.secretName }}
+          {{- with .secret.items }}
+          items:
+            {{- toYaml . | nindent 10 }}
+          {{- end }}
+        {{- else if .persistentVolumeClaim }}
+        persistentVolumeClaim:
+          claimName: {{ .persistentVolumeClaim.claimName }}
+        {{- else if .nfs }}
+        nfs:
+          server: {{ .nfs.server }}
+          path: {{ .nfs.path }}
+        {{- else if .emptyDir }}
+        emptyDir: {}
+        {{- else if .hostPath }}
+        hostPath:
+          path: {{ .hostPath.path }}
+          {{- if .hostPath.type }}
+          type: {{ .hostPath.type }}
+          {{- end }}
+        {{- end }}
+      {{- end }}
+{{- end }}

--- a/helm/slurm/templates/login/login-service.yaml
+++ b/helm/slurm/templates/login/login-service.yaml
@@ -1,0 +1,23 @@
+{{- /*
+SPDX-FileCopyrightText: Copyright (C) SchedMD LLC.
+SPDX-License-Identifier: Apache-2.0
+*/}}
+
+{{- if .Values.login.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "slurm.login.name" . }}
+  namespace: {{ include "slurm.namespace" . }}
+  labels:
+    {{- include "slurm.login.labels" . | nindent 4 }}
+spec:
+  type: ClusterIP
+  selector:
+    {{- include "slurm.login.selectorLabels" . | nindent 4 }}
+  ports:
+    - name: ssh
+      port: 22
+      targetPort: 22
+      protocol: TCP
+{{- end }}

--- a/helm/slurm/templates/loginset/loginset-cr.yaml
+++ b/helm/slurm/templates/loginset/loginset-cr.yaml
@@ -12,6 +12,30 @@ SPDX-License-Identifier: Apache-2.0
 {{- $_ := set $podSpec "imagePullSecrets" $imagePullSecrets -}}
 {{- $priorityClassName := $podSpec.priorityClassName | default $.Values.priorityClassName -}}
 {{- $_ := set $podSpec "priorityClassName" $priorityClassName -}}
+{{- /* Add shared memory volume and mount if shmSize is specified (Together addition) */}}
+{{- if $podSpec.shmSize }}
+  {{- $volumes := $podSpec.volumes | default list -}}
+  {{- $shmVolume := dict "name" "dshm" "emptyDir" (dict "medium" "Memory" "sizeLimit" $podSpec.shmSize) -}}
+  {{- $volumes = append $volumes $shmVolume -}}
+  {{- $_ := set $podSpec "volumes" $volumes -}}
+  {{- $volumeMounts := $loginset.login.volumeMounts | default list -}}
+  {{- $shmVolumeMount := dict "name" "dshm" "mountPath" "/dev/shm" -}}
+  {{- $volumeMounts = append $volumeMounts $shmVolumeMount -}}
+  {{- $_ := set $loginset.login "volumeMounts" $volumeMounts -}}
+{{- end }}
+{{- /* Add existing data claim volumes and mounts (Together addition) */}}
+{{- if and $loginset.persistence $loginset.persistence.existingDataClaims }}
+  {{- $volumes := $podSpec.volumes | default list -}}
+  {{- $volumeMounts := $loginset.login.volumeMounts | default list -}}
+  {{- range $loginset.persistence.existingDataClaims }}
+    {{- $pvcVolume := dict "name" .name "persistentVolumeClaim" (dict "claimName" .name) -}}
+    {{- $volumes = append $volumes $pvcVolume -}}
+    {{- $pvcVolumeMount := dict "name" .name "mountPath" .mountPath -}}
+    {{- $volumeMounts = append $volumeMounts $pvcVolumeMount -}}
+  {{- end }}
+  {{- $_ := set $podSpec "volumes" $volumes -}}
+  {{- $_ := set $loginset.login "volumeMounts" $volumeMounts -}}
+{{- end }}
 {{- $podTemplate := dict "metadata" $podMetadata "spec" $podSpec -}}
 ---
 apiVersion: slinky.slurm.net/v1beta1

--- a/helm/slurm/templates/nodeset/nodeset-cr.yaml
+++ b/helm/slurm/templates/nodeset/nodeset-cr.yaml
@@ -13,6 +13,30 @@ SPDX-License-Identifier: Apache-2.0
 {{- $priorityClassName := $podSpec.priorityClassName | default $.Values.priorityClassName -}}
 {{- $_ := set $podSpec "priorityClassName" $priorityClassName -}}
 {{- $_ := set $podSpec "hostname" (printf "%s-" $key) -}}
+{{- /* Add shared memory volume and mount if shmSize is specified (Together addition) */}}
+{{- if $podSpec.shmSize }}
+  {{- $volumes := $podSpec.volumes | default list -}}
+  {{- $shmVolume := dict "name" "dshm" "emptyDir" (dict "medium" "Memory" "sizeLimit" $podSpec.shmSize) -}}
+  {{- $volumes = append $volumes $shmVolume -}}
+  {{- $_ := set $podSpec "volumes" $volumes -}}
+  {{- $volumeMounts := $nodeset.slurmd.volumeMounts | default list -}}
+  {{- $shmVolumeMount := dict "name" "dshm" "mountPath" "/dev/shm" -}}
+  {{- $volumeMounts = append $volumeMounts $shmVolumeMount -}}
+  {{- $_ := set $nodeset.slurmd "volumeMounts" $volumeMounts -}}
+{{- end }}
+{{- /* Add existing data claim volumes and mounts (Together addition) */}}
+{{- if and $nodeset.persistence $nodeset.persistence.existingDataClaims }}
+  {{- $volumes := $podSpec.volumes | default list -}}
+  {{- $volumeMounts := $nodeset.slurmd.volumeMounts | default list -}}
+  {{- range $nodeset.persistence.existingDataClaims }}
+    {{- $pvcVolume := dict "name" .name "persistentVolumeClaim" (dict "claimName" .name) -}}
+    {{- $volumes = append $volumes $pvcVolume -}}
+    {{- $pvcVolumeMount := dict "name" .name "mountPath" .mountPath -}}
+    {{- $volumeMounts = append $volumeMounts $pvcVolumeMount -}}
+  {{- end }}
+  {{- $_ := set $podSpec "volumes" $volumes -}}
+  {{- $_ := set $nodeset.slurmd "volumeMounts" $volumeMounts -}}
+{{- end }}
 {{- $podTemplate := dict "metadata" $podMetadata "spec" $podSpec -}}
 {{- if $nodeset.useResourceLimits }}
   {{- $envLimts := list (dict "name" "POD_CPUS" "value" (include "slurm.worker.podCpus" $nodeset.slurmd | toString)) (dict "name" "POD_MEMORY" "value" (include "slurm.worker.podMemory" $nodeset.slurmd | toString)) -}}

--- a/helm/slurm/values.yaml
+++ b/helm/slurm/values.yaml
@@ -556,6 +556,8 @@ loginsets:
         # - key: key1
         #   operator: Exists
         #   effect: NoSchedule
+      # -- (string) Set the size of the shared memory for the nodeset.
+      shmSize: 16Gi
       # -- List of volumes to use.
       # Ref: https://kubernetes.io/docs/concepts/storage/volumes/
       volumes: []
@@ -576,6 +578,14 @@ loginsets:
         type: LoadBalancer
       # port: 22
       # nodePort: 32222
+    # -- Persistence configuration for the nodeset.
+    persistence:
+      # -- (list) Existing PersistentVolumeClaims to mount (Together addition)
+      existingDataClaims: []
+        # - name: data-cpu-pv
+        #   mountPath: /data
+        # - name: scratch-gpu-pv
+        #   mountPath: /scratch
 
 # Slurm NodeSet (slurmd) configurations.
 nodesets:
@@ -685,6 +695,8 @@ nodesets:
       tolerations: []
         # - key: nvidia.com/gpu
         #   effect: NoSchedule
+      # -- (string) Set the size of the shared memory for the nodeset.
+      shmSize: 16Gi
       # -- List of volumes to use.
       # Ref: https://kubernetes.io/docs/concepts/storage/volumes/
       volumes: []
@@ -694,6 +706,14 @@ nodesets:
         #     path: /exports/home
     # -- Taint the Kubernetes nodes on which nodeset pods are scheduled with NoExecute
     taintKubeNodes: false
+    # -- Persistence configuration for the nodeset.
+    persistence:
+      # -- (list) Existing PersistentVolumeClaims to mount (Together addition)
+      existingDataClaims: []
+        # - name: data-cpu-pv
+        #   mountPath: /data
+        # - name: scratch-gpu-pv
+        #   mountPath: /scratch
 
 # Slurm partition configurations.
 partitions:
@@ -729,3 +749,93 @@ vendor:
       jobMappingDir: "/var/lib/dcgm-exporter/job-mapping"
       # -- Script execution priority (lower numbers run first)
       scriptPriority: "90"
+
+login:
+  #
+  # -- (bool)
+  # Enables login nodes.
+  enabled: true
+  #
+  # -- (integer)
+  # Set the number of replicas to deploy.
+  replicas: 1
+  #
+  # -- (string)
+  # Set the image pull policy.
+  imagePullPolicy: IfNotPresent
+  #
+  # Set the image to use.
+  image:
+    #
+    # -- (string)
+    # Set the image repository to use.
+    repository: ghcr.io/slinkyproject/login
+    #
+    # -- (string)
+    # Set the image tag to use.
+    tag: 25.05-ubuntu24.04
+  #
+  # -- (object)
+  # The security context given to the container.
+  # Ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container
+  securityContext:
+    privileged: false
+    # capabilities:
+    #   add:
+    #     - SYS_CHROOT
+  #
+  # --(list)
+  # List of volume mounts.
+  # Ref: https://kubernetes.io/docs/concepts/storage/volumes/
+  extraVolumeMounts: []
+    # - name: nfs-home
+    #   mountPath: /home
+    # - name: nfs-data
+    #   mountPath: /mnt/data
+  #
+  # --(list)
+  # Define list of pod volumes.
+  # Ref: https://kubernetes.io/docs/concepts/storage/volumes/
+  extraVolumes: []
+    # - name: nfs-home
+    #   nfs:
+    #     server: nfs-server.example.com
+    #     path: /exports/home/
+    # - name: nfs-data
+    #   persistentVolumeClaim:
+    #     claimName: nfs-data
+  #
+  # -- (string)
+  # Set the priority class to use.
+  # Ref: https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/#priorityclass
+  priorityClassName: ""
+  #
+  # -- (map)
+  # Selector which must match a node's labels for the pod to be scheduled on that node.
+  # Ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
+  nodeSelector:
+    kubernetes.io/os: linux
+  #
+  # -- (object)
+  # Set affinity for Kubernetes Pod scheduling.
+  # Ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity
+  affinity: {}
+  #
+  # -- (list)
+  # Configure pod tolerations.
+  # Ref: https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
+  tolerations: []
+  #
+  # -- (object)
+  # Set container resource requests and limits for Kubernetes Pod scheduling.
+  # Ref: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#resource-requests-and-limits-of-pod-and-container
+  resources: {}
+    # requests:
+    #   cpu: 1
+    #   memory: 1Gi
+    # limits:
+    #   cpu: 2
+    #   memory: 4Gi
+
+#
+# Slurm compute (slurmd) configurations.

--- a/internal/annotations/node.go
+++ b/internal/annotations/node.go
@@ -1,0 +1,14 @@
+// SPDX-FileCopyrightText: Copyright (C) SchedMD LLC.
+// SPDX-License-Identifier: Apache-2.0
+
+package annotations
+
+const (
+	// NodeWeight can be used to set to an int32 that represents the weight of
+	// scheduling a NodeSet Pod compared to other Nodes.
+	// Note that this is honored on a best-effort basis, and so it does not
+	// offer guarantees on Node scheduling order.
+	NodeWeight = "slinky.slurm.net/node-weight"
+	// NodeCordon is used to mark a node as cordoned for Together's use case
+	NodeCordon = "slinky.slurm.net/node-cordon"
+)

--- a/internal/builder/accounting_app.go
+++ b/internal/builder/accounting_app.go
@@ -16,11 +16,11 @@ import (
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
-	slinkyv1beta1 "github.com/SlinkyProject/slurm-operator/api/v1beta1"
-	"github.com/SlinkyProject/slurm-operator/internal/builder/labels"
-	"github.com/SlinkyProject/slurm-operator/internal/builder/metadata"
-	"github.com/SlinkyProject/slurm-operator/internal/utils/crypto"
-	"github.com/SlinkyProject/slurm-operator/internal/utils/structutils"
+	slinkyv1beta1 "github.com/togethercomputer/slurm-operator/api/v1beta1"
+	"github.com/togethercomputer/slurm-operator/internal/builder/labels"
+	"github.com/togethercomputer/slurm-operator/internal/builder/metadata"
+	"github.com/togethercomputer/slurm-operator/internal/utils/crypto"
+	"github.com/togethercomputer/slurm-operator/internal/utils/structutils"
 )
 
 const (

--- a/internal/builder/accounting_app.go
+++ b/internal/builder/accounting_app.go
@@ -27,6 +27,10 @@ const (
 	SlurmdbdPort = 6819
 
 	slurmdbdConfFile = "slurmdbd.conf"
+
+	// Volume names for accounting initContainer fix
+	slurmSecretsTmpVolume = "slurm-secrets-tmp"
+	slurmSecretsTmpDir    = "/tmp/slurm-secrets"
 )
 
 func (b *Builder) BuildAccounting(accounting *slinkyv1beta1.Accounting) (*appsv1.StatefulSet, error) {
@@ -95,14 +99,17 @@ func (b *Builder) accountingPodTemplate(accounting *slinkyv1beta1.Accounting) (c
 		},
 		base: corev1.PodSpec{
 			AutomountServiceAccountToken: ptr.To(false),
+			// InitContainer copies secrets from temp location to /etc/slurm with correct permissions.
+			// This is necessary because Kubernetes projected volumes with FSGroup add group read
+			// permission, but slurmdbd.conf requires exactly 0600 (owner read/write only).
+			InitContainers: []corev1.Container{
+				accountingInitContainer(),
+			},
 			Containers: []corev1.Container{
 				b.slurmdbdContainer(spec.Slurmdbd.Container),
 			},
 			SecurityContext: &corev1.PodSecurityContext{
-				RunAsNonRoot: ptr.To(true),
-				RunAsUser:    ptr.To(slurmUserUid),
-				RunAsGroup:   ptr.To(slurmUserGid),
-				FSGroup:      ptr.To(slurmUserGid),
+				RunAsNonRoot: ptr.To(false), // initContainer needs to run as root
 			},
 			Volumes: accountingVolumes(accounting),
 		},
@@ -114,11 +121,19 @@ func (b *Builder) accountingPodTemplate(accounting *slinkyv1beta1.Accounting) (c
 
 func accountingVolumes(accounting *slinkyv1beta1.Accounting) []corev1.Volume {
 	out := []corev1.Volume{
+		// EmptyDir for /etc/slurm - initContainer copies secrets here with correct permissions
 		{
 			Name: slurmEtcVolume,
 			VolumeSource: corev1.VolumeSource{
+				EmptyDir: &corev1.EmptyDirVolumeSource{},
+			},
+		},
+		// Projected volume with secrets - mounted to temp location, copied by initContainer
+		{
+			Name: slurmSecretsTmpVolume,
+			VolumeSource: corev1.VolumeSource{
 				Projected: &corev1.ProjectedVolumeSource{
-					DefaultMode: ptr.To[int32](0o600),
+					DefaultMode: ptr.To[int32](0o644), // readable by initContainer
 					Sources: []corev1.VolumeProjection{
 						{
 							Secret: &corev1.SecretProjection{
@@ -159,6 +174,35 @@ func accountingVolumes(accounting *slinkyv1beta1.Accounting) []corev1.Volume {
 	return out
 }
 
+// accountingInitContainer creates an init container that copies secrets from the
+// projected volume to an emptyDir with correct ownership (slurm:slurm) and
+// permissions (0600 for slurmdbd.conf, 0400 for keys).
+// This is necessary because Kubernetes projected volumes with FSGroup add group
+// read permission, but slurmdbd.conf requires exactly 0600 (owner read/write only).
+func accountingInitContainer() corev1.Container {
+	return corev1.Container{
+		Name:  "init-slurm-config",
+		Image: "busybox:1.36",
+		Command: []string{
+			"sh", "-c",
+			`cp /tmp/slurm-secrets/* /etc/slurm/ && \
+			chown -R 401:401 /etc/slurm && \
+			chmod 600 /etc/slurm/slurmdbd.conf && \
+			chmod 400 /etc/slurm/slurm.key && \
+			chmod 400 /etc/slurm/jwt_hs256.key && \
+			ls -la /etc/slurm/`,
+		},
+		SecurityContext: &corev1.SecurityContext{
+			RunAsUser:  ptr.To[int64](0), // Run as root to chown
+			RunAsGroup: ptr.To[int64](0),
+		},
+		VolumeMounts: []corev1.VolumeMount{
+			{Name: slurmSecretsTmpVolume, MountPath: slurmSecretsTmpDir, ReadOnly: true},
+			{Name: slurmEtcVolume, MountPath: slurmEtcDir},
+		},
+	}
+}
+
 func (b *Builder) slurmdbdContainer(merge corev1.Container) corev1.Container {
 	opts := ContainerOpts{
 		base: corev1.Container{
@@ -183,7 +227,7 @@ func (b *Builder) slurmdbdContainer(merge corev1.Container) corev1.Container {
 				RunAsGroup:   ptr.To(slurmUserGid),
 			},
 			VolumeMounts: []corev1.VolumeMount{
-				{Name: slurmEtcVolume, MountPath: slurmEtcDir, ReadOnly: true},
+				{Name: slurmEtcVolume, MountPath: slurmEtcDir}, // emptyDir populated by initContainer
 				{Name: slurmPidFileVolume, MountPath: slurmPidFileDir},
 			},
 		},

--- a/internal/builder/accounting_app_test.go
+++ b/internal/builder/accounting_app_test.go
@@ -7,8 +7,8 @@ import (
 	_ "embed"
 	"testing"
 
-	slinkyv1beta1 "github.com/SlinkyProject/slurm-operator/api/v1beta1"
-	"github.com/SlinkyProject/slurm-operator/internal/builder/labels"
+	slinkyv1beta1 "github.com/togethercomputer/slurm-operator/api/v1beta1"
+	"github.com/togethercomputer/slurm-operator/internal/builder/labels"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 	"k8s.io/utils/set"

--- a/internal/builder/accounting_config.go
+++ b/internal/builder/accounting_config.go
@@ -8,10 +8,10 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 
-	slinkyv1beta1 "github.com/SlinkyProject/slurm-operator/api/v1beta1"
-	"github.com/SlinkyProject/slurm-operator/internal/builder/labels"
-	"github.com/SlinkyProject/slurm-operator/internal/utils/config"
-	"github.com/SlinkyProject/slurm-operator/internal/utils/structutils"
+	slinkyv1beta1 "github.com/togethercomputer/slurm-operator/api/v1beta1"
+	"github.com/togethercomputer/slurm-operator/internal/builder/labels"
+	"github.com/togethercomputer/slurm-operator/internal/utils/config"
+	"github.com/togethercomputer/slurm-operator/internal/utils/structutils"
 )
 
 func (b *Builder) BuildAccountingConfig(accounting *slinkyv1beta1.Accounting) (*corev1.Secret, error) {

--- a/internal/builder/accounting_config_test.go
+++ b/internal/builder/accounting_config_test.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"testing"
 
-	slinkyv1beta1 "github.com/SlinkyProject/slurm-operator/api/v1beta1"
+	slinkyv1beta1 "github.com/togethercomputer/slurm-operator/api/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"

--- a/internal/builder/accounting_service.go
+++ b/internal/builder/accounting_service.go
@@ -7,9 +7,9 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 
-	slinkyv1beta1 "github.com/SlinkyProject/slurm-operator/api/v1beta1"
-	"github.com/SlinkyProject/slurm-operator/internal/builder/labels"
-	"github.com/SlinkyProject/slurm-operator/internal/utils/structutils"
+	slinkyv1beta1 "github.com/togethercomputer/slurm-operator/api/v1beta1"
+	"github.com/togethercomputer/slurm-operator/internal/builder/labels"
+	"github.com/togethercomputer/slurm-operator/internal/utils/structutils"
 )
 
 func (b *Builder) BuildAccountingService(accounting *slinkyv1beta1.Accounting) (*corev1.Service, error) {

--- a/internal/builder/accounting_service_test.go
+++ b/internal/builder/accounting_service_test.go
@@ -6,7 +6,7 @@ package builder
 import (
 	"testing"
 
-	slinkyv1beta1 "github.com/SlinkyProject/slurm-operator/api/v1beta1"
+	slinkyv1beta1 "github.com/togethercomputer/slurm-operator/api/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/set"

--- a/internal/builder/builder.go
+++ b/internal/builder/builder.go
@@ -4,7 +4,7 @@
 package builder
 
 import (
-	"github.com/SlinkyProject/slurm-operator/internal/utils/refresolver"
+	"github.com/togethercomputer/slurm-operator/internal/utils/refresolver"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 

--- a/internal/builder/builder_test.go
+++ b/internal/builder/builder_test.go
@@ -7,8 +7,8 @@ import (
 	"reflect"
 	"testing"
 
-	slinkyv1beta1 "github.com/SlinkyProject/slurm-operator/api/v1beta1"
-	"github.com/SlinkyProject/slurm-operator/internal/utils/refresolver"
+	slinkyv1beta1 "github.com/togethercomputer/slurm-operator/api/v1beta1"
+	"github.com/togethercomputer/slurm-operator/internal/utils/refresolver"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client"

--- a/internal/builder/common.go
+++ b/internal/builder/common.go
@@ -12,10 +12,10 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/utils/ptr"
 
-	slinkyv1beta1 "github.com/SlinkyProject/slurm-operator/api/v1beta1"
-	"github.com/SlinkyProject/slurm-operator/internal/builder/labels"
-	"github.com/SlinkyProject/slurm-operator/internal/utils/domainname"
-	"github.com/SlinkyProject/slurm-operator/internal/utils/structutils"
+	slinkyv1beta1 "github.com/togethercomputer/slurm-operator/api/v1beta1"
+	"github.com/togethercomputer/slurm-operator/internal/builder/labels"
+	"github.com/togethercomputer/slurm-operator/internal/utils/domainname"
+	"github.com/togethercomputer/slurm-operator/internal/utils/structutils"
 )
 
 const (

--- a/internal/builder/configmap.go
+++ b/internal/builder/configmap.go
@@ -12,8 +12,8 @@ import (
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
-	slinkyv1beta1 "github.com/SlinkyProject/slurm-operator/api/v1beta1"
-	"github.com/SlinkyProject/slurm-operator/internal/builder/metadata"
+	slinkyv1beta1 "github.com/togethercomputer/slurm-operator/api/v1beta1"
+	"github.com/togethercomputer/slurm-operator/internal/builder/metadata"
 )
 
 type ConfigMapOpts struct {

--- a/internal/builder/configmap_test.go
+++ b/internal/builder/configmap_test.go
@@ -6,8 +6,8 @@ package builder
 import (
 	"testing"
 
-	slinkyv1beta1 "github.com/SlinkyProject/slurm-operator/api/v1beta1"
-	"github.com/SlinkyProject/slurm-operator/internal/utils/objectutils"
+	slinkyv1beta1 "github.com/togethercomputer/slurm-operator/api/v1beta1"
+	"github.com/togethercomputer/slurm-operator/internal/utils/objectutils"
 	appsv1 "k8s.io/api/apps/v1"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/internal/builder/container.go
+++ b/internal/builder/container.go
@@ -6,8 +6,8 @@ package builder
 import (
 	corev1 "k8s.io/api/core/v1"
 
-	"github.com/SlinkyProject/slurm-operator/internal/utils/reflectutils"
-	"github.com/SlinkyProject/slurm-operator/internal/utils/structutils"
+	"github.com/togethercomputer/slurm-operator/internal/utils/reflectutils"
+	"github.com/togethercomputer/slurm-operator/internal/utils/structutils"
 )
 
 type ContainerOpts struct {

--- a/internal/builder/controller_app.go
+++ b/internal/builder/controller_app.go
@@ -15,9 +15,9 @@ import (
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
-	slinkyv1beta1 "github.com/SlinkyProject/slurm-operator/api/v1beta1"
-	"github.com/SlinkyProject/slurm-operator/internal/builder/labels"
-	"github.com/SlinkyProject/slurm-operator/internal/builder/metadata"
+	slinkyv1beta1 "github.com/togethercomputer/slurm-operator/api/v1beta1"
+	"github.com/togethercomputer/slurm-operator/internal/builder/labels"
+	"github.com/togethercomputer/slurm-operator/internal/builder/metadata"
 )
 
 const (

--- a/internal/builder/controller_app.go
+++ b/internal/builder/controller_app.go
@@ -242,27 +242,24 @@ func (b *Builder) slurmctldContainer(merge corev1.Container, clusterName string)
 			},
 			StartupProbe: &corev1.Probe{
 				ProbeHandler: corev1.ProbeHandler{
-					HTTPGet: &corev1.HTTPGetAction{
-						Path: "/livez",
-						Port: intstr.FromString(labels.ControllerApp),
+					TCPSocket: &corev1.TCPSocketAction{
+						Port: intstr.FromInt(SlurmctldPort),
 					},
 				},
-				FailureThreshold: 6,
+				FailureThreshold: 30,
 				PeriodSeconds:    10,
 			},
 			ReadinessProbe: &corev1.Probe{
 				ProbeHandler: corev1.ProbeHandler{
-					HTTPGet: &corev1.HTTPGetAction{
-						Path: "/readyz",
-						Port: intstr.FromString(labels.ControllerApp),
+					TCPSocket: &corev1.TCPSocketAction{
+						Port: intstr.FromInt(SlurmctldPort),
 					},
 				},
 			},
 			LivenessProbe: &corev1.Probe{
 				ProbeHandler: corev1.ProbeHandler{
-					HTTPGet: &corev1.HTTPGetAction{
-						Path: "/livez",
-						Port: intstr.FromString(labels.ControllerApp),
+					TCPSocket: &corev1.TCPSocketAction{
+						Port: intstr.FromInt(SlurmctldPort),
 					},
 				},
 				FailureThreshold: 6,

--- a/internal/builder/controller_app_test.go
+++ b/internal/builder/controller_app_test.go
@@ -7,8 +7,8 @@ import (
 	_ "embed"
 	"testing"
 
-	slinkyv1beta1 "github.com/SlinkyProject/slurm-operator/api/v1beta1"
-	"github.com/SlinkyProject/slurm-operator/internal/builder/labels"
+	slinkyv1beta1 "github.com/togethercomputer/slurm-operator/api/v1beta1"
+	"github.com/togethercomputer/slurm-operator/internal/builder/labels"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 	"k8s.io/utils/set"

--- a/internal/builder/controller_config.go
+++ b/internal/builder/controller_config.go
@@ -15,10 +15,10 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 
-	slinkyv1beta1 "github.com/SlinkyProject/slurm-operator/api/v1beta1"
-	"github.com/SlinkyProject/slurm-operator/internal/builder/labels"
-	"github.com/SlinkyProject/slurm-operator/internal/utils/config"
-	"github.com/SlinkyProject/slurm-operator/internal/utils/structutils"
+	slinkyv1beta1 "github.com/togethercomputer/slurm-operator/api/v1beta1"
+	"github.com/togethercomputer/slurm-operator/internal/builder/labels"
+	"github.com/togethercomputer/slurm-operator/internal/utils/config"
+	"github.com/togethercomputer/slurm-operator/internal/utils/structutils"
 )
 
 const (

--- a/internal/builder/controller_config_test.go
+++ b/internal/builder/controller_config_test.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"testing"
 
-	slinkyv1beta1 "github.com/SlinkyProject/slurm-operator/api/v1beta1"
+	slinkyv1beta1 "github.com/togethercomputer/slurm-operator/api/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"

--- a/internal/builder/controller_service.go
+++ b/internal/builder/controller_service.go
@@ -7,9 +7,9 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 
-	slinkyv1beta1 "github.com/SlinkyProject/slurm-operator/api/v1beta1"
-	"github.com/SlinkyProject/slurm-operator/internal/builder/labels"
-	"github.com/SlinkyProject/slurm-operator/internal/utils/structutils"
+	slinkyv1beta1 "github.com/togethercomputer/slurm-operator/api/v1beta1"
+	"github.com/togethercomputer/slurm-operator/internal/builder/labels"
+	"github.com/togethercomputer/slurm-operator/internal/utils/structutils"
 )
 
 func (b *Builder) BuildControllerService(controller *slinkyv1beta1.Controller) (*corev1.Service, error) {

--- a/internal/builder/controller_service_test.go
+++ b/internal/builder/controller_service_test.go
@@ -6,7 +6,7 @@ package builder
 import (
 	"testing"
 
-	slinkyv1beta1 "github.com/SlinkyProject/slurm-operator/api/v1beta1"
+	slinkyv1beta1 "github.com/togethercomputer/slurm-operator/api/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/set"

--- a/internal/builder/controller_servicemonitor.go
+++ b/internal/builder/controller_servicemonitor.go
@@ -7,9 +7,9 @@ import (
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	slinkyv1beta1 "github.com/SlinkyProject/slurm-operator/api/v1beta1"
-	"github.com/SlinkyProject/slurm-operator/internal/builder/labels"
-	"github.com/SlinkyProject/slurm-operator/internal/utils/reflectutils"
+	slinkyv1beta1 "github.com/togethercomputer/slurm-operator/api/v1beta1"
+	"github.com/togethercomputer/slurm-operator/internal/builder/labels"
+	"github.com/togethercomputer/slurm-operator/internal/utils/reflectutils"
 )
 
 func (b *Builder) BuildControllerServiceMonitor(controller *slinkyv1beta1.Controller) (*monitoringv1.ServiceMonitor, error) {

--- a/internal/builder/controller_servicemonitor_test.go
+++ b/internal/builder/controller_servicemonitor_test.go
@@ -6,9 +6,9 @@ package builder_test
 import (
 	"testing"
 
-	slinkyv1beta1 "github.com/SlinkyProject/slurm-operator/api/v1beta1"
-	"github.com/SlinkyProject/slurm-operator/internal/builder"
-	"github.com/SlinkyProject/slurm-operator/internal/utils/testutils"
+	slinkyv1beta1 "github.com/togethercomputer/slurm-operator/api/v1beta1"
+	"github.com/togethercomputer/slurm-operator/internal/builder"
+	"github.com/togethercomputer/slurm-operator/internal/utils/testutils"
 	"k8s.io/utils/set"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"

--- a/internal/builder/labels/labels.go
+++ b/internal/builder/labels/labels.go
@@ -6,7 +6,7 @@ package labels
 import (
 	"maps"
 
-	slinkyv1beta1 "github.com/SlinkyProject/slurm-operator/api/v1beta1"
+	slinkyv1beta1 "github.com/togethercomputer/slurm-operator/api/v1beta1"
 )
 
 // Ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/#labels

--- a/internal/builder/labels/labels_test.go
+++ b/internal/builder/labels/labels_test.go
@@ -6,7 +6,7 @@ package labels
 import (
 	"testing"
 
-	slinkyv1beta1 "github.com/SlinkyProject/slurm-operator/api/v1beta1"
+	slinkyv1beta1 "github.com/togethercomputer/slurm-operator/api/v1beta1"
 	"k8s.io/apimachinery/pkg/api/equality"
 )
 

--- a/internal/builder/login_app.go
+++ b/internal/builder/login_app.go
@@ -17,10 +17,10 @@ import (
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
-	slinkyv1beta1 "github.com/SlinkyProject/slurm-operator/api/v1beta1"
-	"github.com/SlinkyProject/slurm-operator/internal/builder/labels"
-	"github.com/SlinkyProject/slurm-operator/internal/builder/metadata"
-	"github.com/SlinkyProject/slurm-operator/internal/utils/crypto"
+	slinkyv1beta1 "github.com/togethercomputer/slurm-operator/api/v1beta1"
+	"github.com/togethercomputer/slurm-operator/internal/builder/labels"
+	"github.com/togethercomputer/slurm-operator/internal/builder/metadata"
+	"github.com/togethercomputer/slurm-operator/internal/utils/crypto"
 )
 
 const (

--- a/internal/builder/login_app_test.go
+++ b/internal/builder/login_app_test.go
@@ -7,8 +7,8 @@ import (
 	_ "embed"
 	"testing"
 
-	slinkyv1beta1 "github.com/SlinkyProject/slurm-operator/api/v1beta1"
-	"github.com/SlinkyProject/slurm-operator/internal/builder/labels"
+	slinkyv1beta1 "github.com/togethercomputer/slurm-operator/api/v1beta1"
+	"github.com/togethercomputer/slurm-operator/internal/builder/labels"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/set"
 	"sigs.k8s.io/controller-runtime/pkg/client"

--- a/internal/builder/login_config.go
+++ b/internal/builder/login_config.go
@@ -6,10 +6,10 @@ package builder
 import (
 	corev1 "k8s.io/api/core/v1"
 
-	slinkyv1beta1 "github.com/SlinkyProject/slurm-operator/api/v1beta1"
-	"github.com/SlinkyProject/slurm-operator/internal/builder/labels"
-	"github.com/SlinkyProject/slurm-operator/internal/utils/config"
-	"github.com/SlinkyProject/slurm-operator/internal/utils/structutils"
+	slinkyv1beta1 "github.com/togethercomputer/slurm-operator/api/v1beta1"
+	"github.com/togethercomputer/slurm-operator/internal/builder/labels"
+	"github.com/togethercomputer/slurm-operator/internal/utils/config"
+	"github.com/togethercomputer/slurm-operator/internal/utils/structutils"
 )
 
 func (b *Builder) BuildLoginSshConfig(loginset *slinkyv1beta1.LoginSet) (*corev1.ConfigMap, error) {

--- a/internal/builder/login_config_test.go
+++ b/internal/builder/login_config_test.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"testing"
 
-	slinkyv1beta1 "github.com/SlinkyProject/slurm-operator/api/v1beta1"
+	slinkyv1beta1 "github.com/togethercomputer/slurm-operator/api/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"

--- a/internal/builder/login_secret.go
+++ b/internal/builder/login_secret.go
@@ -8,10 +8,10 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 
-	slinkyv1beta1 "github.com/SlinkyProject/slurm-operator/api/v1beta1"
-	"github.com/SlinkyProject/slurm-operator/internal/builder/labels"
-	"github.com/SlinkyProject/slurm-operator/internal/utils/crypto"
-	"github.com/SlinkyProject/slurm-operator/internal/utils/structutils"
+	slinkyv1beta1 "github.com/togethercomputer/slurm-operator/api/v1beta1"
+	"github.com/togethercomputer/slurm-operator/internal/builder/labels"
+	"github.com/togethercomputer/slurm-operator/internal/utils/crypto"
+	"github.com/togethercomputer/slurm-operator/internal/utils/structutils"
 )
 
 func (b *Builder) BuildLoginSshHostKeys(loginset *slinkyv1beta1.LoginSet) (*corev1.Secret, error) {

--- a/internal/builder/login_secret_test.go
+++ b/internal/builder/login_secret_test.go
@@ -6,7 +6,7 @@ package builder
 import (
 	"testing"
 
-	slinkyv1beta1 "github.com/SlinkyProject/slurm-operator/api/v1beta1"
+	slinkyv1beta1 "github.com/togethercomputer/slurm-operator/api/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"

--- a/internal/builder/login_service.go
+++ b/internal/builder/login_service.go
@@ -7,9 +7,9 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 
-	slinkyv1beta1 "github.com/SlinkyProject/slurm-operator/api/v1beta1"
-	"github.com/SlinkyProject/slurm-operator/internal/builder/labels"
-	"github.com/SlinkyProject/slurm-operator/internal/utils/structutils"
+	slinkyv1beta1 "github.com/togethercomputer/slurm-operator/api/v1beta1"
+	"github.com/togethercomputer/slurm-operator/internal/builder/labels"
+	"github.com/togethercomputer/slurm-operator/internal/utils/structutils"
 )
 
 func (b *Builder) BuildLoginService(loginset *slinkyv1beta1.LoginSet) (*corev1.Service, error) {

--- a/internal/builder/login_service_test.go
+++ b/internal/builder/login_service_test.go
@@ -6,7 +6,7 @@ package builder
 import (
 	"testing"
 
-	slinkyv1beta1 "github.com/SlinkyProject/slurm-operator/api/v1beta1"
+	slinkyv1beta1 "github.com/togethercomputer/slurm-operator/api/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/set"

--- a/internal/builder/metadata/metadata.go
+++ b/internal/builder/metadata/metadata.go
@@ -9,7 +9,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
-	slinkyv1beta1 "github.com/SlinkyProject/slurm-operator/api/v1beta1"
+	slinkyv1beta1 "github.com/togethercomputer/slurm-operator/api/v1beta1"
 )
 
 type MetadataBuilder struct {

--- a/internal/builder/metadata/metadata_test.go
+++ b/internal/builder/metadata/metadata_test.go
@@ -6,7 +6,7 @@ package metadata
 import (
 	"testing"
 
-	slinkyv1beta1 "github.com/SlinkyProject/slurm-operator/api/v1beta1"
+	slinkyv1beta1 "github.com/togethercomputer/slurm-operator/api/v1beta1"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"

--- a/internal/builder/pod_disruption_budget.go
+++ b/internal/builder/pod_disruption_budget.go
@@ -11,8 +11,8 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
-	slinkyv1beta1 "github.com/SlinkyProject/slurm-operator/api/v1beta1"
-	"github.com/SlinkyProject/slurm-operator/internal/builder/metadata"
+	slinkyv1beta1 "github.com/togethercomputer/slurm-operator/api/v1beta1"
+	"github.com/togethercomputer/slurm-operator/internal/builder/metadata"
 )
 
 type PodDisruptionBudgetOpts struct {

--- a/internal/builder/pod_template.go
+++ b/internal/builder/pod_template.go
@@ -7,10 +7,10 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 
-	slinkyv1beta1 "github.com/SlinkyProject/slurm-operator/api/v1beta1"
-	"github.com/SlinkyProject/slurm-operator/internal/builder/metadata"
-	"github.com/SlinkyProject/slurm-operator/internal/utils/reflectutils"
-	"github.com/SlinkyProject/slurm-operator/internal/utils/structutils"
+	slinkyv1beta1 "github.com/togethercomputer/slurm-operator/api/v1beta1"
+	"github.com/togethercomputer/slurm-operator/internal/builder/metadata"
+	"github.com/togethercomputer/slurm-operator/internal/utils/reflectutils"
+	"github.com/togethercomputer/slurm-operator/internal/utils/structutils"
 )
 
 type PodTemplateOpts struct {

--- a/internal/builder/restapi_app.go
+++ b/internal/builder/restapi_app.go
@@ -17,9 +17,9 @@ import (
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
-	slinkyv1beta1 "github.com/SlinkyProject/slurm-operator/api/v1beta1"
-	"github.com/SlinkyProject/slurm-operator/internal/builder/labels"
-	"github.com/SlinkyProject/slurm-operator/internal/builder/metadata"
+	slinkyv1beta1 "github.com/togethercomputer/slurm-operator/api/v1beta1"
+	"github.com/togethercomputer/slurm-operator/internal/builder/labels"
+	"github.com/togethercomputer/slurm-operator/internal/builder/metadata"
 )
 
 const (

--- a/internal/builder/restapi_app_test.go
+++ b/internal/builder/restapi_app_test.go
@@ -7,8 +7,8 @@ import (
 	_ "embed"
 	"testing"
 
-	slinkyv1beta1 "github.com/SlinkyProject/slurm-operator/api/v1beta1"
-	"github.com/SlinkyProject/slurm-operator/internal/builder/labels"
+	slinkyv1beta1 "github.com/togethercomputer/slurm-operator/api/v1beta1"
+	"github.com/togethercomputer/slurm-operator/internal/builder/labels"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 	"k8s.io/utils/set"

--- a/internal/builder/restapi_service.go
+++ b/internal/builder/restapi_service.go
@@ -7,9 +7,9 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 
-	slinkyv1beta1 "github.com/SlinkyProject/slurm-operator/api/v1beta1"
-	"github.com/SlinkyProject/slurm-operator/internal/builder/labels"
-	"github.com/SlinkyProject/slurm-operator/internal/utils/structutils"
+	slinkyv1beta1 "github.com/togethercomputer/slurm-operator/api/v1beta1"
+	"github.com/togethercomputer/slurm-operator/internal/builder/labels"
+	"github.com/togethercomputer/slurm-operator/internal/utils/structutils"
 )
 
 func (b *Builder) BuildRestapiService(restapi *slinkyv1beta1.RestApi) (*corev1.Service, error) {

--- a/internal/builder/restapi_service_test.go
+++ b/internal/builder/restapi_service_test.go
@@ -6,7 +6,7 @@ package builder
 import (
 	"testing"
 
-	slinkyv1beta1 "github.com/SlinkyProject/slurm-operator/api/v1beta1"
+	slinkyv1beta1 "github.com/togethercomputer/slurm-operator/api/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/set"

--- a/internal/builder/secret.go
+++ b/internal/builder/secret.go
@@ -12,8 +12,8 @@ import (
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
-	slinkyv1beta1 "github.com/SlinkyProject/slurm-operator/api/v1beta1"
-	"github.com/SlinkyProject/slurm-operator/internal/builder/metadata"
+	slinkyv1beta1 "github.com/togethercomputer/slurm-operator/api/v1beta1"
+	"github.com/togethercomputer/slurm-operator/internal/builder/metadata"
 )
 
 type SecretOpts struct {

--- a/internal/builder/secret_test.go
+++ b/internal/builder/secret_test.go
@@ -6,8 +6,8 @@ package builder
 import (
 	"testing"
 
-	slinkyv1beta1 "github.com/SlinkyProject/slurm-operator/api/v1beta1"
-	"github.com/SlinkyProject/slurm-operator/internal/utils/objectutils"
+	slinkyv1beta1 "github.com/togethercomputer/slurm-operator/api/v1beta1"
+	"github.com/togethercomputer/slurm-operator/internal/utils/objectutils"
 	appsv1 "k8s.io/api/apps/v1"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/internal/builder/service.go
+++ b/internal/builder/service.go
@@ -11,9 +11,9 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
-	slinkyv1beta1 "github.com/SlinkyProject/slurm-operator/api/v1beta1"
-	"github.com/SlinkyProject/slurm-operator/internal/builder/metadata"
-	"github.com/SlinkyProject/slurm-operator/internal/utils/structutils"
+	slinkyv1beta1 "github.com/togethercomputer/slurm-operator/api/v1beta1"
+	"github.com/togethercomputer/slurm-operator/internal/builder/metadata"
+	"github.com/togethercomputer/slurm-operator/internal/utils/structutils"
 )
 
 type ServiceOpts struct {

--- a/internal/builder/service_test.go
+++ b/internal/builder/service_test.go
@@ -6,8 +6,8 @@ package builder
 import (
 	"testing"
 
-	slinkyv1beta1 "github.com/SlinkyProject/slurm-operator/api/v1beta1"
-	"github.com/SlinkyProject/slurm-operator/internal/utils/objectutils"
+	slinkyv1beta1 "github.com/togethercomputer/slurm-operator/api/v1beta1"
+	"github.com/togethercomputer/slurm-operator/internal/utils/objectutils"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"

--- a/internal/builder/servicemonitor.go
+++ b/internal/builder/servicemonitor.go
@@ -11,10 +11,10 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
-	slinkyv1beta1 "github.com/SlinkyProject/slurm-operator/api/v1beta1"
-	"github.com/SlinkyProject/slurm-operator/internal/builder/metadata"
-	"github.com/SlinkyProject/slurm-operator/internal/utils/reflectutils"
-	"github.com/SlinkyProject/slurm-operator/internal/utils/structutils"
+	slinkyv1beta1 "github.com/togethercomputer/slurm-operator/api/v1beta1"
+	"github.com/togethercomputer/slurm-operator/internal/builder/metadata"
+	"github.com/togethercomputer/slurm-operator/internal/utils/reflectutils"
+	"github.com/togethercomputer/slurm-operator/internal/utils/structutils"
 )
 
 type ServiceMonitorOpts struct {

--- a/internal/builder/servicemonitor_test.go
+++ b/internal/builder/servicemonitor_test.go
@@ -6,7 +6,7 @@ package builder_test
 import (
 	"testing"
 
-	"github.com/SlinkyProject/slurm-operator/internal/builder"
+	"github.com/togethercomputer/slurm-operator/internal/builder"
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	corev1 "k8s.io/api/core/v1"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"

--- a/internal/builder/token_secret.go
+++ b/internal/builder/token_secret.go
@@ -9,8 +9,8 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 
-	slinkyv1beta1 "github.com/SlinkyProject/slurm-operator/api/v1beta1"
-	"github.com/SlinkyProject/slurm-operator/internal/controller/token/slurmjwt"
+	slinkyv1beta1 "github.com/togethercomputer/slurm-operator/api/v1beta1"
+	"github.com/togethercomputer/slurm-operator/internal/controller/token/slurmjwt"
 )
 
 func (b *Builder) BuildTokenSecret(token *slinkyv1beta1.Token) (*corev1.Secret, error) {

--- a/internal/builder/token_secret_test.go
+++ b/internal/builder/token_secret_test.go
@@ -7,7 +7,7 @@ import (
 	_ "embed"
 	"testing"
 
-	slinkyv1beta1 "github.com/SlinkyProject/slurm-operator/api/v1beta1"
+	slinkyv1beta1 "github.com/togethercomputer/slurm-operator/api/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"

--- a/internal/builder/worker_app.go
+++ b/internal/builder/worker_app.go
@@ -15,10 +15,10 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/utils/ptr"
 
-	slinkyv1beta1 "github.com/SlinkyProject/slurm-operator/api/v1beta1"
-	"github.com/SlinkyProject/slurm-operator/internal/builder/labels"
-	"github.com/SlinkyProject/slurm-operator/internal/builder/metadata"
-	slurmtaints "github.com/SlinkyProject/slurm-operator/pkg/taints"
+	slinkyv1beta1 "github.com/togethercomputer/slurm-operator/api/v1beta1"
+	"github.com/togethercomputer/slurm-operator/internal/builder/labels"
+	"github.com/togethercomputer/slurm-operator/internal/builder/metadata"
+	slurmtaints "github.com/togethercomputer/slurm-operator/pkg/taints"
 )
 
 const (

--- a/internal/builder/worker_app.go
+++ b/internal/builder/worker_app.go
@@ -121,19 +121,17 @@ func (b *Builder) slurmdContainer(nodeset *slinkyv1beta1.NodeSet, controller *sl
 			},
 			StartupProbe: &corev1.Probe{
 				ProbeHandler: corev1.ProbeHandler{
-					HTTPGet: &corev1.HTTPGetAction{
-						Path: "/livez",
-						Port: intstr.FromString(labels.WorkerApp),
+					TCPSocket: &corev1.TCPSocketAction{
+						Port: intstr.FromInt(SlurmdPort),
 					},
 				},
-				FailureThreshold: 6,
+				FailureThreshold: 30,
 				PeriodSeconds:    10,
 			},
 			LivenessProbe: &corev1.Probe{
 				ProbeHandler: corev1.ProbeHandler{
-					HTTPGet: &corev1.HTTPGetAction{
-						Path: "/livez",
-						Port: intstr.FromString(labels.WorkerApp),
+					TCPSocket: &corev1.TCPSocketAction{
+						Port: intstr.FromInt(SlurmdPort),
 					},
 				},
 				FailureThreshold: 6,
@@ -141,9 +139,8 @@ func (b *Builder) slurmdContainer(nodeset *slinkyv1beta1.NodeSet, controller *sl
 			},
 			ReadinessProbe: &corev1.Probe{
 				ProbeHandler: corev1.ProbeHandler{
-					HTTPGet: &corev1.HTTPGetAction{
-						Path: "/readyz",
-						Port: intstr.FromString(labels.WorkerApp),
+					TCPSocket: &corev1.TCPSocketAction{
+						Port: intstr.FromInt(SlurmdPort),
 					},
 				},
 			},

--- a/internal/builder/worker_app_test.go
+++ b/internal/builder/worker_app_test.go
@@ -8,8 +8,8 @@ import (
 	"strings"
 	"testing"
 
-	slinkyv1beta1 "github.com/SlinkyProject/slurm-operator/api/v1beta1"
-	"github.com/SlinkyProject/slurm-operator/internal/builder/labels"
+	slinkyv1beta1 "github.com/togethercomputer/slurm-operator/api/v1beta1"
+	"github.com/togethercomputer/slurm-operator/internal/builder/labels"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8slabels "k8s.io/apimachinery/pkg/labels"

--- a/internal/builder/worker_pdb.go
+++ b/internal/builder/worker_pdb.go
@@ -13,8 +13,8 @@ import (
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
-	slinkyv1beta1 "github.com/SlinkyProject/slurm-operator/api/v1beta1"
-	"github.com/SlinkyProject/slurm-operator/internal/builder/labels"
+	slinkyv1beta1 "github.com/togethercomputer/slurm-operator/api/v1beta1"
+	"github.com/togethercomputer/slurm-operator/internal/builder/labels"
 )
 
 // BuildClusterWorkerPodDisruptionBudget creates a single PodDisruptionBudget for ALL worker NodeSets in the same Slurm cluster

--- a/internal/builder/worker_service.go
+++ b/internal/builder/worker_service.go
@@ -11,8 +11,8 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
-	slinkyv1beta1 "github.com/SlinkyProject/slurm-operator/api/v1beta1"
-	"github.com/SlinkyProject/slurm-operator/internal/builder/labels"
+	slinkyv1beta1 "github.com/togethercomputer/slurm-operator/api/v1beta1"
+	"github.com/togethercomputer/slurm-operator/internal/builder/labels"
 )
 
 // BuildClusterWorkerService creates a single headless service for ALL worker NodeSets in the same Slurm cluster

--- a/internal/builder/worker_service_test.go
+++ b/internal/builder/worker_service_test.go
@@ -6,7 +6,7 @@ package builder
 import (
 	"testing"
 
-	slinkyv1beta1 "github.com/SlinkyProject/slurm-operator/api/v1beta1"
+	slinkyv1beta1 "github.com/togethercomputer/slurm-operator/api/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"

--- a/internal/controller/accounting/accounting_controller.go
+++ b/internal/controller/accounting/accounting_controller.go
@@ -21,11 +21,11 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
-	slinkyv1beta1 "github.com/SlinkyProject/slurm-operator/api/v1beta1"
-	"github.com/SlinkyProject/slurm-operator/internal/builder"
-	"github.com/SlinkyProject/slurm-operator/internal/controller/accounting/eventhandler"
-	"github.com/SlinkyProject/slurm-operator/internal/utils/durationstore"
-	"github.com/SlinkyProject/slurm-operator/internal/utils/refresolver"
+	slinkyv1beta1 "github.com/togethercomputer/slurm-operator/api/v1beta1"
+	"github.com/togethercomputer/slurm-operator/internal/builder"
+	"github.com/togethercomputer/slurm-operator/internal/controller/accounting/eventhandler"
+	"github.com/togethercomputer/slurm-operator/internal/utils/durationstore"
+	"github.com/togethercomputer/slurm-operator/internal/utils/refresolver"
 )
 
 const (

--- a/internal/controller/accounting/accounting_controller_test.go
+++ b/internal/controller/accounting/accounting_controller_test.go
@@ -10,8 +10,8 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	slinkyv1beta1 "github.com/SlinkyProject/slurm-operator/api/v1beta1"
-	"github.com/SlinkyProject/slurm-operator/internal/utils/testutils"
+	slinkyv1beta1 "github.com/togethercomputer/slurm-operator/api/v1beta1"
+	"github.com/togethercomputer/slurm-operator/internal/utils/testutils"
 )
 
 var _ = Describe("Accounting controller", func() {

--- a/internal/controller/accounting/accounting_sync.go
+++ b/internal/controller/accounting/accounting_sync.go
@@ -13,8 +13,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
-	slinkyv1beta1 "github.com/SlinkyProject/slurm-operator/api/v1beta1"
-	"github.com/SlinkyProject/slurm-operator/internal/utils/objectutils"
+	slinkyv1beta1 "github.com/togethercomputer/slurm-operator/api/v1beta1"
+	"github.com/togethercomputer/slurm-operator/internal/utils/objectutils"
 )
 
 type SyncStep struct {

--- a/internal/controller/accounting/accounting_sync_status.go
+++ b/internal/controller/accounting/accounting_sync_status.go
@@ -15,7 +15,7 @@ import (
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
-	slinkyv1beta1 "github.com/SlinkyProject/slurm-operator/api/v1beta1"
+	slinkyv1beta1 "github.com/togethercomputer/slurm-operator/api/v1beta1"
 )
 
 // syncStatus handles determining and updating the status.

--- a/internal/controller/accounting/eventhandler/eventhandler_accounting.go
+++ b/internal/controller/accounting/eventhandler/eventhandler_accounting.go
@@ -13,9 +13,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
-	slinkyv1beta1 "github.com/SlinkyProject/slurm-operator/api/v1beta1"
-	"github.com/SlinkyProject/slurm-operator/internal/utils/objectutils"
-	"github.com/SlinkyProject/slurm-operator/internal/utils/refresolver"
+	slinkyv1beta1 "github.com/togethercomputer/slurm-operator/api/v1beta1"
+	"github.com/togethercomputer/slurm-operator/internal/utils/objectutils"
+	"github.com/togethercomputer/slurm-operator/internal/utils/refresolver"
 )
 
 func NewAccountingEventHandler(reader client.Reader) *AccountingEventHandler {

--- a/internal/controller/accounting/eventhandler/eventhandler_accounting_test.go
+++ b/internal/controller/accounting/eventhandler/eventhandler_accounting_test.go
@@ -7,7 +7,7 @@ import (
 	"context"
 	"testing"
 
-	slinkyv1beta1 "github.com/SlinkyProject/slurm-operator/api/v1beta1"
+	slinkyv1beta1 "github.com/togethercomputer/slurm-operator/api/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/util/workqueue"
 	"sigs.k8s.io/controller-runtime/pkg/client"

--- a/internal/controller/accounting/eventhandler/eventhandler_secret.go
+++ b/internal/controller/accounting/eventhandler/eventhandler_secret.go
@@ -14,8 +14,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
-	slinkyv1beta1 "github.com/SlinkyProject/slurm-operator/api/v1beta1"
-	"github.com/SlinkyProject/slurm-operator/internal/utils/objectutils"
+	slinkyv1beta1 "github.com/togethercomputer/slurm-operator/api/v1beta1"
+	"github.com/togethercomputer/slurm-operator/internal/utils/objectutils"
 )
 
 func NewSecretEventHandler(reader client.Reader) *SecretEventHandler {

--- a/internal/controller/accounting/eventhandler/eventhandler_secret_test.go
+++ b/internal/controller/accounting/eventhandler/eventhandler_secret_test.go
@@ -13,7 +13,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
-	"github.com/SlinkyProject/slurm-operator/internal/utils/testutils"
+	"github.com/togethercomputer/slurm-operator/internal/utils/testutils"
 )
 
 func Test_SecretEventHandler_Create(t *testing.T) {

--- a/internal/controller/accounting/eventhandler/utils_test.go
+++ b/internal/controller/accounting/eventhandler/utils_test.go
@@ -9,7 +9,7 @@ import (
 	"k8s.io/client-go/util/workqueue"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
-	slinkyv1beta1 "github.com/SlinkyProject/slurm-operator/api/v1beta1"
+	slinkyv1beta1 "github.com/togethercomputer/slurm-operator/api/v1beta1"
 )
 
 func init() {

--- a/internal/controller/accounting/suite_test.go
+++ b/internal/controller/accounting/suite_test.go
@@ -21,8 +21,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	"sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
-	slinkyv1beta1 "github.com/SlinkyProject/slurm-operator/api/v1beta1"
-	"github.com/SlinkyProject/slurm-operator/internal/utils/testutils"
+	slinkyv1beta1 "github.com/togethercomputer/slurm-operator/api/v1beta1"
+	"github.com/togethercomputer/slurm-operator/internal/utils/testutils"
 	//+kubebuilder:scaffold:imports
 )
 

--- a/internal/controller/controller/controller_controller.go
+++ b/internal/controller/controller/controller_controller.go
@@ -21,12 +21,12 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
-	slinkyv1beta1 "github.com/SlinkyProject/slurm-operator/api/v1beta1"
-	"github.com/SlinkyProject/slurm-operator/internal/builder"
-	"github.com/SlinkyProject/slurm-operator/internal/clientmap"
-	"github.com/SlinkyProject/slurm-operator/internal/controller/controller/eventhandler"
-	"github.com/SlinkyProject/slurm-operator/internal/utils/durationstore"
-	"github.com/SlinkyProject/slurm-operator/internal/utils/refresolver"
+	slinkyv1beta1 "github.com/togethercomputer/slurm-operator/api/v1beta1"
+	"github.com/togethercomputer/slurm-operator/internal/builder"
+	"github.com/togethercomputer/slurm-operator/internal/clientmap"
+	"github.com/togethercomputer/slurm-operator/internal/controller/controller/eventhandler"
+	"github.com/togethercomputer/slurm-operator/internal/utils/durationstore"
+	"github.com/togethercomputer/slurm-operator/internal/utils/refresolver"
 )
 
 const (

--- a/internal/controller/controller/controller_controller_test.go
+++ b/internal/controller/controller/controller_controller_test.go
@@ -11,8 +11,8 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 
-	slinkyv1beta1 "github.com/SlinkyProject/slurm-operator/api/v1beta1"
-	"github.com/SlinkyProject/slurm-operator/internal/utils/testutils"
+	slinkyv1beta1 "github.com/togethercomputer/slurm-operator/api/v1beta1"
+	"github.com/togethercomputer/slurm-operator/internal/utils/testutils"
 )
 
 var _ = Describe("Slurm Controller", func() {

--- a/internal/controller/controller/controller_sync.go
+++ b/internal/controller/controller/controller_sync.go
@@ -14,8 +14,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
-	slinkyv1beta1 "github.com/SlinkyProject/slurm-operator/api/v1beta1"
-	"github.com/SlinkyProject/slurm-operator/internal/utils/objectutils"
+	slinkyv1beta1 "github.com/togethercomputer/slurm-operator/api/v1beta1"
+	"github.com/togethercomputer/slurm-operator/internal/utils/objectutils"
 )
 
 type SyncStep struct {

--- a/internal/controller/controller/controller_sync_status.go
+++ b/internal/controller/controller/controller_sync_status.go
@@ -15,7 +15,7 @@ import (
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
-	slinkyv1beta1 "github.com/SlinkyProject/slurm-operator/api/v1beta1"
+	slinkyv1beta1 "github.com/togethercomputer/slurm-operator/api/v1beta1"
 )
 
 // syncStatus handles determining and updating the status.

--- a/internal/controller/controller/eventhandler/eventhandler_accounting.go
+++ b/internal/controller/controller/eventhandler/eventhandler_accounting.go
@@ -13,9 +13,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
-	slinkyv1beta1 "github.com/SlinkyProject/slurm-operator/api/v1beta1"
-	"github.com/SlinkyProject/slurm-operator/internal/utils/objectutils"
-	"github.com/SlinkyProject/slurm-operator/internal/utils/refresolver"
+	slinkyv1beta1 "github.com/togethercomputer/slurm-operator/api/v1beta1"
+	"github.com/togethercomputer/slurm-operator/internal/utils/objectutils"
+	"github.com/togethercomputer/slurm-operator/internal/utils/refresolver"
 )
 
 func NewAccountingEventHandler(reader client.Reader) *AccountingEventHandler {

--- a/internal/controller/controller/eventhandler/eventhandler_accounting_test.go
+++ b/internal/controller/controller/eventhandler/eventhandler_accounting_test.go
@@ -7,7 +7,7 @@ import (
 	"context"
 	"testing"
 
-	slinkyv1beta1 "github.com/SlinkyProject/slurm-operator/api/v1beta1"
+	slinkyv1beta1 "github.com/togethercomputer/slurm-operator/api/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/util/workqueue"
 	"sigs.k8s.io/controller-runtime/pkg/client"

--- a/internal/controller/controller/eventhandler/eventhandler_nodeset.go
+++ b/internal/controller/controller/eventhandler/eventhandler_nodeset.go
@@ -12,9 +12,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
-	slinkyv1beta1 "github.com/SlinkyProject/slurm-operator/api/v1beta1"
-	"github.com/SlinkyProject/slurm-operator/internal/utils/objectutils"
-	"github.com/SlinkyProject/slurm-operator/internal/utils/refresolver"
+	slinkyv1beta1 "github.com/togethercomputer/slurm-operator/api/v1beta1"
+	"github.com/togethercomputer/slurm-operator/internal/utils/objectutils"
+	"github.com/togethercomputer/slurm-operator/internal/utils/refresolver"
 )
 
 func NewNodeSetEventHandler(reader client.Reader) *NodesetEventHandler {

--- a/internal/controller/controller/eventhandler/eventhandler_nodeset_test.go
+++ b/internal/controller/controller/eventhandler/eventhandler_nodeset_test.go
@@ -15,8 +15,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
-	slinkyv1beta1 "github.com/SlinkyProject/slurm-operator/api/v1beta1"
-	"github.com/SlinkyProject/slurm-operator/internal/utils/testutils"
+	slinkyv1beta1 "github.com/togethercomputer/slurm-operator/api/v1beta1"
+	"github.com/togethercomputer/slurm-operator/internal/utils/testutils"
 )
 
 func Test_NodeSetEventHandler_Create(t *testing.T) {

--- a/internal/controller/controller/eventhandler/eventhandler_secret.go
+++ b/internal/controller/controller/eventhandler/eventhandler_secret.go
@@ -14,8 +14,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
-	slinkyv1beta1 "github.com/SlinkyProject/slurm-operator/api/v1beta1"
-	"github.com/SlinkyProject/slurm-operator/internal/utils/objectutils"
+	slinkyv1beta1 "github.com/togethercomputer/slurm-operator/api/v1beta1"
+	"github.com/togethercomputer/slurm-operator/internal/utils/objectutils"
 )
 
 func NewSecretEventHandler(reader client.Reader) *SecretEventHandler {

--- a/internal/controller/controller/eventhandler/eventhandler_secret_test.go
+++ b/internal/controller/controller/eventhandler/eventhandler_secret_test.go
@@ -13,7 +13,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
-	"github.com/SlinkyProject/slurm-operator/internal/utils/testutils"
+	"github.com/togethercomputer/slurm-operator/internal/utils/testutils"
 )
 
 func Test_SecretEventHandler_Create(t *testing.T) {

--- a/internal/controller/controller/eventhandler/utils_test.go
+++ b/internal/controller/controller/eventhandler/utils_test.go
@@ -9,7 +9,7 @@ import (
 	"k8s.io/client-go/util/workqueue"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
-	slinkyv1beta1 "github.com/SlinkyProject/slurm-operator/api/v1beta1"
+	slinkyv1beta1 "github.com/togethercomputer/slurm-operator/api/v1beta1"
 )
 
 func init() {

--- a/internal/controller/controller/suite_test.go
+++ b/internal/controller/controller/suite_test.go
@@ -21,9 +21,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	"sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
-	slinkyv1beta1 "github.com/SlinkyProject/slurm-operator/api/v1beta1"
-	"github.com/SlinkyProject/slurm-operator/internal/clientmap"
-	"github.com/SlinkyProject/slurm-operator/internal/utils/testutils"
+	slinkyv1beta1 "github.com/togethercomputer/slurm-operator/api/v1beta1"
+	"github.com/togethercomputer/slurm-operator/internal/clientmap"
+	"github.com/togethercomputer/slurm-operator/internal/utils/testutils"
 	//+kubebuilder:scaffold:imports
 )
 

--- a/internal/controller/loginset/eventhandler/eventhandler_loginset.go
+++ b/internal/controller/loginset/eventhandler/eventhandler_loginset.go
@@ -13,9 +13,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
-	slinkyv1beta1 "github.com/SlinkyProject/slurm-operator/api/v1beta1"
-	"github.com/SlinkyProject/slurm-operator/internal/utils/objectutils"
-	"github.com/SlinkyProject/slurm-operator/internal/utils/refresolver"
+	slinkyv1beta1 "github.com/togethercomputer/slurm-operator/api/v1beta1"
+	"github.com/togethercomputer/slurm-operator/internal/utils/objectutils"
+	"github.com/togethercomputer/slurm-operator/internal/utils/refresolver"
 )
 
 func NewControllerEventHandler(reader client.Reader) *ControllerEventHandler {

--- a/internal/controller/loginset/eventhandler/eventhandler_loginset_test.go
+++ b/internal/controller/loginset/eventhandler/eventhandler_loginset_test.go
@@ -7,7 +7,7 @@ import (
 	"context"
 	"testing"
 
-	slinkyv1beta1 "github.com/SlinkyProject/slurm-operator/api/v1beta1"
+	slinkyv1beta1 "github.com/togethercomputer/slurm-operator/api/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/util/workqueue"
 	"sigs.k8s.io/controller-runtime/pkg/client"

--- a/internal/controller/loginset/eventhandler/eventhandler_secret.go
+++ b/internal/controller/loginset/eventhandler/eventhandler_secret.go
@@ -14,9 +14,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
-	slinkyv1beta1 "github.com/SlinkyProject/slurm-operator/api/v1beta1"
-	"github.com/SlinkyProject/slurm-operator/internal/utils/objectutils"
-	"github.com/SlinkyProject/slurm-operator/internal/utils/refresolver"
+	slinkyv1beta1 "github.com/togethercomputer/slurm-operator/api/v1beta1"
+	"github.com/togethercomputer/slurm-operator/internal/utils/objectutils"
+	"github.com/togethercomputer/slurm-operator/internal/utils/refresolver"
 )
 
 func NewSecretEventHandler(reader client.Reader) *SecretEventHandler {

--- a/internal/controller/loginset/eventhandler/eventhandler_secret_test.go
+++ b/internal/controller/loginset/eventhandler/eventhandler_secret_test.go
@@ -13,7 +13,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
-	"github.com/SlinkyProject/slurm-operator/internal/utils/testutils"
+	"github.com/togethercomputer/slurm-operator/internal/utils/testutils"
 )
 
 func Test_SecretEventHandler_Create(t *testing.T) {

--- a/internal/controller/loginset/eventhandler/utils_test.go
+++ b/internal/controller/loginset/eventhandler/utils_test.go
@@ -9,7 +9,7 @@ import (
 	"k8s.io/client-go/util/workqueue"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
-	slinkyv1beta1 "github.com/SlinkyProject/slurm-operator/api/v1beta1"
+	slinkyv1beta1 "github.com/togethercomputer/slurm-operator/api/v1beta1"
 )
 
 func init() {

--- a/internal/controller/loginset/loginset_controller.go
+++ b/internal/controller/loginset/loginset_controller.go
@@ -21,11 +21,11 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
-	slinkyv1beta1 "github.com/SlinkyProject/slurm-operator/api/v1beta1"
-	"github.com/SlinkyProject/slurm-operator/internal/builder"
-	"github.com/SlinkyProject/slurm-operator/internal/controller/loginset/eventhandler"
-	"github.com/SlinkyProject/slurm-operator/internal/utils/durationstore"
-	"github.com/SlinkyProject/slurm-operator/internal/utils/refresolver"
+	slinkyv1beta1 "github.com/togethercomputer/slurm-operator/api/v1beta1"
+	"github.com/togethercomputer/slurm-operator/internal/builder"
+	"github.com/togethercomputer/slurm-operator/internal/controller/loginset/eventhandler"
+	"github.com/togethercomputer/slurm-operator/internal/utils/durationstore"
+	"github.com/togethercomputer/slurm-operator/internal/utils/refresolver"
 )
 
 const (

--- a/internal/controller/loginset/loginset_controller_test.go
+++ b/internal/controller/loginset/loginset_controller_test.go
@@ -11,8 +11,8 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 
-	slinkyv1beta1 "github.com/SlinkyProject/slurm-operator/api/v1beta1"
-	"github.com/SlinkyProject/slurm-operator/internal/utils/testutils"
+	slinkyv1beta1 "github.com/togethercomputer/slurm-operator/api/v1beta1"
+	"github.com/togethercomputer/slurm-operator/internal/utils/testutils"
 )
 
 var _ = Describe("LoginSet Controller", func() {

--- a/internal/controller/loginset/loginset_sync.go
+++ b/internal/controller/loginset/loginset_sync.go
@@ -14,8 +14,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
-	slinkyv1beta1 "github.com/SlinkyProject/slurm-operator/api/v1beta1"
-	"github.com/SlinkyProject/slurm-operator/internal/utils/objectutils"
+	slinkyv1beta1 "github.com/togethercomputer/slurm-operator/api/v1beta1"
+	"github.com/togethercomputer/slurm-operator/internal/utils/objectutils"
 )
 
 type SyncStep struct {

--- a/internal/controller/loginset/loginset_sync_status.go
+++ b/internal/controller/loginset/loginset_sync_status.go
@@ -17,8 +17,8 @@ import (
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
-	slinkyv1beta1 "github.com/SlinkyProject/slurm-operator/api/v1beta1"
-	"github.com/SlinkyProject/slurm-operator/internal/builder/labels"
+	slinkyv1beta1 "github.com/togethercomputer/slurm-operator/api/v1beta1"
+	"github.com/togethercomputer/slurm-operator/internal/builder/labels"
 )
 
 // syncStatus handles determining and updating the status.

--- a/internal/controller/loginset/suite_test.go
+++ b/internal/controller/loginset/suite_test.go
@@ -21,8 +21,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	"sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
-	slinkyv1beta1 "github.com/SlinkyProject/slurm-operator/api/v1beta1"
-	"github.com/SlinkyProject/slurm-operator/internal/utils/testutils"
+	slinkyv1beta1 "github.com/togethercomputer/slurm-operator/api/v1beta1"
+	"github.com/togethercomputer/slurm-operator/internal/utils/testutils"
 	//+kubebuilder:scaffold:imports
 )
 

--- a/internal/controller/nodeset/eventhandler/eventhandler_controller.go
+++ b/internal/controller/nodeset/eventhandler/eventhandler_controller.go
@@ -13,9 +13,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
-	slinkyv1beta1 "github.com/SlinkyProject/slurm-operator/api/v1beta1"
-	"github.com/SlinkyProject/slurm-operator/internal/utils/objectutils"
-	"github.com/SlinkyProject/slurm-operator/internal/utils/refresolver"
+	slinkyv1beta1 "github.com/togethercomputer/slurm-operator/api/v1beta1"
+	"github.com/togethercomputer/slurm-operator/internal/utils/objectutils"
+	"github.com/togethercomputer/slurm-operator/internal/utils/refresolver"
 )
 
 func NewControllerEventHandler(reader client.Reader) *ControllerEventHandler {

--- a/internal/controller/nodeset/eventhandler/eventhandler_controller_test.go
+++ b/internal/controller/nodeset/eventhandler/eventhandler_controller_test.go
@@ -13,7 +13,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
-	"github.com/SlinkyProject/slurm-operator/internal/utils/testutils"
+	"github.com/togethercomputer/slurm-operator/internal/utils/testutils"
 )
 
 func Test_ControllerEventHandler_Create(t *testing.T) {

--- a/internal/controller/nodeset/eventhandler/eventhandler_node.go
+++ b/internal/controller/nodeset/eventhandler/eventhandler_node.go
@@ -18,8 +18,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
-	slinkyv1beta1 "github.com/SlinkyProject/slurm-operator/api/v1beta1"
-	"github.com/SlinkyProject/slurm-operator/internal/utils/objectutils"
+	slinkyv1beta1 "github.com/togethercomputer/slurm-operator/api/v1beta1"
+	"github.com/togethercomputer/slurm-operator/internal/utils/objectutils"
 )
 
 func NewNodeEventHandler(reader client.Reader) *NodeEventHandler {

--- a/internal/controller/nodeset/eventhandler/eventhandler_node_test.go
+++ b/internal/controller/nodeset/eventhandler/eventhandler_node_test.go
@@ -15,9 +15,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
-	slinkyv1beta1 "github.com/SlinkyProject/slurm-operator/api/v1beta1"
-	"github.com/SlinkyProject/slurm-operator/internal/controller/nodeset/indexes"
-	nodesetutils "github.com/SlinkyProject/slurm-operator/internal/controller/nodeset/utils"
+	slinkyv1beta1 "github.com/togethercomputer/slurm-operator/api/v1beta1"
+	"github.com/togethercomputer/slurm-operator/internal/controller/nodeset/indexes"
+	nodesetutils "github.com/togethercomputer/slurm-operator/internal/controller/nodeset/utils"
 )
 
 func Test_NodeEventHandler_Create(t *testing.T) {

--- a/internal/controller/nodeset/eventhandler/eventhandler_pod.go
+++ b/internal/controller/nodeset/eventhandler/eventhandler_pod.go
@@ -30,11 +30,11 @@ import (
 	slurmclient "github.com/SlinkyProject/slurm-client/pkg/client"
 	slurmtypes "github.com/SlinkyProject/slurm-client/pkg/types"
 
-	slinkyv1beta1 "github.com/SlinkyProject/slurm-operator/api/v1beta1"
-	"github.com/SlinkyProject/slurm-operator/internal/builder/labels"
-	nodesetutils "github.com/SlinkyProject/slurm-operator/internal/controller/nodeset/utils"
-	"github.com/SlinkyProject/slurm-operator/internal/utils/objectutils"
-	"github.com/SlinkyProject/slurm-operator/internal/utils/podinfo"
+	slinkyv1beta1 "github.com/togethercomputer/slurm-operator/api/v1beta1"
+	"github.com/togethercomputer/slurm-operator/internal/builder/labels"
+	nodesetutils "github.com/togethercomputer/slurm-operator/internal/controller/nodeset/utils"
+	"github.com/togethercomputer/slurm-operator/internal/utils/objectutils"
+	"github.com/togethercomputer/slurm-operator/internal/utils/podinfo"
 )
 
 func NewPodEventHandler(reader client.Reader, expectations *kubecontroller.UIDTrackingControllerExpectations) *PodEventHandler {

--- a/internal/controller/nodeset/eventhandler/eventhandler_secret.go
+++ b/internal/controller/nodeset/eventhandler/eventhandler_secret.go
@@ -14,9 +14,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
-	slinkyv1beta1 "github.com/SlinkyProject/slurm-operator/api/v1beta1"
-	"github.com/SlinkyProject/slurm-operator/internal/utils/objectutils"
-	"github.com/SlinkyProject/slurm-operator/internal/utils/refresolver"
+	slinkyv1beta1 "github.com/togethercomputer/slurm-operator/api/v1beta1"
+	"github.com/togethercomputer/slurm-operator/internal/utils/objectutils"
+	"github.com/togethercomputer/slurm-operator/internal/utils/refresolver"
 )
 
 func NewSecretEventHandler(reader client.Reader) *SecretEventHandler {

--- a/internal/controller/nodeset/eventhandler/eventhandler_secret_test.go
+++ b/internal/controller/nodeset/eventhandler/eventhandler_secret_test.go
@@ -13,7 +13,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
-	"github.com/SlinkyProject/slurm-operator/internal/utils/testutils"
+	"github.com/togethercomputer/slurm-operator/internal/utils/testutils"
 )
 
 func Test_SecretEventHandler_Create(t *testing.T) {

--- a/internal/controller/nodeset/eventhandler/utils_test.go
+++ b/internal/controller/nodeset/eventhandler/utils_test.go
@@ -12,7 +12,7 @@ import (
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
-	slinkyv1beta1 "github.com/SlinkyProject/slurm-operator/api/v1beta1"
+	slinkyv1beta1 "github.com/togethercomputer/slurm-operator/api/v1beta1"
 )
 
 func init() {

--- a/internal/controller/nodeset/nodeset_controller.go
+++ b/internal/controller/nodeset/nodeset_controller.go
@@ -23,16 +23,16 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
-	slinkyv1beta1 "github.com/SlinkyProject/slurm-operator/api/v1beta1"
-	"github.com/SlinkyProject/slurm-operator/internal/builder"
-	"github.com/SlinkyProject/slurm-operator/internal/clientmap"
-	"github.com/SlinkyProject/slurm-operator/internal/controller/nodeset/eventhandler"
-	"github.com/SlinkyProject/slurm-operator/internal/controller/nodeset/indexes"
-	"github.com/SlinkyProject/slurm-operator/internal/controller/nodeset/podcontrol"
-	"github.com/SlinkyProject/slurm-operator/internal/controller/nodeset/slurmcontrol"
-	"github.com/SlinkyProject/slurm-operator/internal/utils/durationstore"
-	"github.com/SlinkyProject/slurm-operator/internal/utils/historycontrol"
-	"github.com/SlinkyProject/slurm-operator/internal/utils/refresolver"
+	slinkyv1beta1 "github.com/togethercomputer/slurm-operator/api/v1beta1"
+	"github.com/togethercomputer/slurm-operator/internal/builder"
+	"github.com/togethercomputer/slurm-operator/internal/clientmap"
+	"github.com/togethercomputer/slurm-operator/internal/controller/nodeset/eventhandler"
+	"github.com/togethercomputer/slurm-operator/internal/controller/nodeset/indexes"
+	"github.com/togethercomputer/slurm-operator/internal/controller/nodeset/podcontrol"
+	"github.com/togethercomputer/slurm-operator/internal/controller/nodeset/slurmcontrol"
+	"github.com/togethercomputer/slurm-operator/internal/utils/durationstore"
+	"github.com/togethercomputer/slurm-operator/internal/utils/historycontrol"
+	"github.com/togethercomputer/slurm-operator/internal/utils/refresolver"
 )
 
 const (

--- a/internal/controller/nodeset/nodeset_controller_test.go
+++ b/internal/controller/nodeset/nodeset_controller_test.go
@@ -22,9 +22,9 @@ import (
 	"github.com/SlinkyProject/slurm-client/pkg/object"
 	slurmtypes "github.com/SlinkyProject/slurm-client/pkg/types"
 
-	slinkyv1beta1 "github.com/SlinkyProject/slurm-operator/api/v1beta1"
-	nodesetutils "github.com/SlinkyProject/slurm-operator/internal/controller/nodeset/utils"
-	"github.com/SlinkyProject/slurm-operator/internal/utils/testutils"
+	slinkyv1beta1 "github.com/togethercomputer/slurm-operator/api/v1beta1"
+	nodesetutils "github.com/togethercomputer/slurm-operator/internal/controller/nodeset/utils"
+	"github.com/togethercomputer/slurm-operator/internal/utils/testutils"
 )
 
 func newFakeClientList(interceptorFuncs interceptor.Funcs, initObjLists ...object.ObjectList) slurmclient.Client {

--- a/internal/controller/nodeset/nodeset_history.go
+++ b/internal/controller/nodeset/nodeset_history.go
@@ -14,8 +14,8 @@ import (
 	"k8s.io/kubernetes/pkg/controller/history"
 	"k8s.io/utils/ptr"
 
-	slinkyv1beta1 "github.com/SlinkyProject/slurm-operator/api/v1beta1"
-	"github.com/SlinkyProject/slurm-operator/internal/utils/historycontrol"
+	slinkyv1beta1 "github.com/togethercomputer/slurm-operator/api/v1beta1"
+	"github.com/togethercomputer/slurm-operator/internal/utils/historycontrol"
 )
 
 // truncateHistory truncates any non-live ControllerRevisions in revisions from nodeset's history. The UpdateRevision and

--- a/internal/controller/nodeset/nodeset_history_test.go
+++ b/internal/controller/nodeset/nodeset_history_test.go
@@ -18,8 +18,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
-	slinkyv1beta1 "github.com/SlinkyProject/slurm-operator/api/v1beta1"
-	"github.com/SlinkyProject/slurm-operator/internal/utils/structutils"
+	slinkyv1beta1 "github.com/togethercomputer/slurm-operator/api/v1beta1"
+	"github.com/togethercomputer/slurm-operator/internal/utils/structutils"
 )
 
 func TestNodeSetReconciler_truncateHistory(t *testing.T) {

--- a/internal/controller/nodeset/nodeset_sync_status.go
+++ b/internal/controller/nodeset/nodeset_sync_status.go
@@ -22,16 +22,16 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
-	slinkyv1beta1 "github.com/SlinkyProject/slurm-operator/api/v1beta1"
-	"github.com/SlinkyProject/slurm-operator/internal/builder/labels"
-	"github.com/SlinkyProject/slurm-operator/internal/controller/nodeset/slurmcontrol"
-	nodesetutils "github.com/SlinkyProject/slurm-operator/internal/controller/nodeset/utils"
-	"github.com/SlinkyProject/slurm-operator/internal/utils"
-	"github.com/SlinkyProject/slurm-operator/internal/utils/historycontrol"
-	"github.com/SlinkyProject/slurm-operator/internal/utils/mathutils"
-	"github.com/SlinkyProject/slurm-operator/internal/utils/podutils"
-	"github.com/SlinkyProject/slurm-operator/internal/utils/structutils"
-	slurmconditions "github.com/SlinkyProject/slurm-operator/pkg/conditions"
+	slinkyv1beta1 "github.com/togethercomputer/slurm-operator/api/v1beta1"
+	"github.com/togethercomputer/slurm-operator/internal/builder/labels"
+	"github.com/togethercomputer/slurm-operator/internal/controller/nodeset/slurmcontrol"
+	nodesetutils "github.com/togethercomputer/slurm-operator/internal/controller/nodeset/utils"
+	"github.com/togethercomputer/slurm-operator/internal/utils"
+	"github.com/togethercomputer/slurm-operator/internal/utils/historycontrol"
+	"github.com/togethercomputer/slurm-operator/internal/utils/mathutils"
+	"github.com/togethercomputer/slurm-operator/internal/utils/podutils"
+	"github.com/togethercomputer/slurm-operator/internal/utils/structutils"
+	slurmconditions "github.com/togethercomputer/slurm-operator/pkg/conditions"
 )
 
 // syncStatus handles synchronizing Slurm Nodes and NodeSet Status.

--- a/internal/controller/nodeset/nodeset_sync_status_test.go
+++ b/internal/controller/nodeset/nodeset_sync_status_test.go
@@ -21,12 +21,12 @@ import (
 
 	slurminterceptor "github.com/SlinkyProject/slurm-client/pkg/client/interceptor"
 	slurmtypes "github.com/SlinkyProject/slurm-client/pkg/types"
-	slinkyv1beta1 "github.com/SlinkyProject/slurm-operator/api/v1beta1"
-	"github.com/SlinkyProject/slurm-operator/internal/clientmap"
-	"github.com/SlinkyProject/slurm-operator/internal/controller/nodeset/slurmcontrol"
-	nodesetutils "github.com/SlinkyProject/slurm-operator/internal/controller/nodeset/utils"
-	"github.com/SlinkyProject/slurm-operator/internal/utils/structutils"
-	slurmconditions "github.com/SlinkyProject/slurm-operator/pkg/conditions"
+	slinkyv1beta1 "github.com/togethercomputer/slurm-operator/api/v1beta1"
+	"github.com/togethercomputer/slurm-operator/internal/clientmap"
+	"github.com/togethercomputer/slurm-operator/internal/controller/nodeset/slurmcontrol"
+	nodesetutils "github.com/togethercomputer/slurm-operator/internal/controller/nodeset/utils"
+	"github.com/togethercomputer/slurm-operator/internal/utils/structutils"
+	slurmconditions "github.com/togethercomputer/slurm-operator/pkg/conditions"
 )
 
 func TestNodeSetReconciler_syncStatus(t *testing.T) {

--- a/internal/controller/nodeset/nodeset_sync_test.go
+++ b/internal/controller/nodeset/nodeset_sync_test.go
@@ -38,17 +38,17 @@ import (
 	slurmobject "github.com/SlinkyProject/slurm-client/pkg/object"
 	slurmtypes "github.com/SlinkyProject/slurm-client/pkg/types"
 
-	slinkyv1beta1 "github.com/SlinkyProject/slurm-operator/api/v1beta1"
-	"github.com/SlinkyProject/slurm-operator/internal/builder"
-	"github.com/SlinkyProject/slurm-operator/internal/builder/labels"
-	"github.com/SlinkyProject/slurm-operator/internal/clientmap"
-	"github.com/SlinkyProject/slurm-operator/internal/controller/nodeset/podcontrol"
-	"github.com/SlinkyProject/slurm-operator/internal/controller/nodeset/slurmcontrol"
-	nodesetutils "github.com/SlinkyProject/slurm-operator/internal/controller/nodeset/utils"
-	"github.com/SlinkyProject/slurm-operator/internal/utils/historycontrol"
-	"github.com/SlinkyProject/slurm-operator/internal/utils/podutils"
-	"github.com/SlinkyProject/slurm-operator/internal/utils/structutils"
-	slurmtaints "github.com/SlinkyProject/slurm-operator/pkg/taints"
+	slinkyv1beta1 "github.com/togethercomputer/slurm-operator/api/v1beta1"
+	"github.com/togethercomputer/slurm-operator/internal/builder"
+	"github.com/togethercomputer/slurm-operator/internal/builder/labels"
+	"github.com/togethercomputer/slurm-operator/internal/clientmap"
+	"github.com/togethercomputer/slurm-operator/internal/controller/nodeset/podcontrol"
+	"github.com/togethercomputer/slurm-operator/internal/controller/nodeset/slurmcontrol"
+	nodesetutils "github.com/togethercomputer/slurm-operator/internal/controller/nodeset/utils"
+	"github.com/togethercomputer/slurm-operator/internal/utils/historycontrol"
+	"github.com/togethercomputer/slurm-operator/internal/utils/podutils"
+	"github.com/togethercomputer/slurm-operator/internal/utils/structutils"
+	slurmtaints "github.com/togethercomputer/slurm-operator/pkg/taints"
 )
 
 func newNodeSetController(client client.Client, clientMap *clientmap.ClientMap) *NodeSetReconciler {

--- a/internal/controller/nodeset/podcontrol/podcontrol.go
+++ b/internal/controller/nodeset/podcontrol/podcontrol.go
@@ -23,10 +23,10 @@ import (
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	slinkyv1beta1 "github.com/SlinkyProject/slurm-operator/api/v1beta1"
-	nodesetutils "github.com/SlinkyProject/slurm-operator/internal/controller/nodeset/utils"
-	"github.com/SlinkyProject/slurm-operator/internal/utils/podcontrol"
-	"github.com/SlinkyProject/slurm-operator/internal/utils/podutils"
+	slinkyv1beta1 "github.com/togethercomputer/slurm-operator/api/v1beta1"
+	nodesetutils "github.com/togethercomputer/slurm-operator/internal/controller/nodeset/utils"
+	"github.com/togethercomputer/slurm-operator/internal/utils/podcontrol"
+	"github.com/togethercomputer/slurm-operator/internal/utils/podutils"
 )
 
 const (

--- a/internal/controller/nodeset/podcontrol/podcontrol_test.go
+++ b/internal/controller/nodeset/podcontrol/podcontrol_test.go
@@ -26,9 +26,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
-	slinkyv1beta1 "github.com/SlinkyProject/slurm-operator/api/v1beta1"
-	nodesetutils "github.com/SlinkyProject/slurm-operator/internal/controller/nodeset/utils"
-	"github.com/SlinkyProject/slurm-operator/internal/utils/podcontrol"
+	slinkyv1beta1 "github.com/togethercomputer/slurm-operator/api/v1beta1"
+	nodesetutils "github.com/togethercomputer/slurm-operator/internal/controller/nodeset/utils"
+	"github.com/togethercomputer/slurm-operator/internal/utils/podcontrol"
 )
 
 func newPodControl(client client.Client, recorder record.EventRecorder) *realPodControl {

--- a/internal/controller/nodeset/slurmcontrol/slurmcontrol.go
+++ b/internal/controller/nodeset/slurmcontrol/slurmcontrol.go
@@ -23,12 +23,12 @@ import (
 	slurmobject "github.com/SlinkyProject/slurm-client/pkg/object"
 	slurmtypes "github.com/SlinkyProject/slurm-client/pkg/types"
 
-	slinkyv1beta1 "github.com/SlinkyProject/slurm-operator/api/v1beta1"
-	"github.com/SlinkyProject/slurm-operator/internal/clientmap"
-	nodesetutils "github.com/SlinkyProject/slurm-operator/internal/controller/nodeset/utils"
-	"github.com/SlinkyProject/slurm-operator/internal/utils/podinfo"
-	"github.com/SlinkyProject/slurm-operator/internal/utils/timestore"
-	slurmconditions "github.com/SlinkyProject/slurm-operator/pkg/conditions"
+	slinkyv1beta1 "github.com/togethercomputer/slurm-operator/api/v1beta1"
+	"github.com/togethercomputer/slurm-operator/internal/clientmap"
+	nodesetutils "github.com/togethercomputer/slurm-operator/internal/controller/nodeset/utils"
+	"github.com/togethercomputer/slurm-operator/internal/utils/podinfo"
+	"github.com/togethercomputer/slurm-operator/internal/utils/timestore"
+	slurmconditions "github.com/togethercomputer/slurm-operator/pkg/conditions"
 )
 
 type SlurmControlInterface interface {

--- a/internal/controller/nodeset/slurmcontrol/slurmcontrol.go
+++ b/internal/controller/nodeset/slurmcontrol/slurmcontrol.go
@@ -72,6 +72,10 @@ func (r *realSlurmControl) RefreshNodeCache(ctx context.Context, nodeset *slinky
 	nodeList := &slurmtypes.V0044NodeList{}
 	opts := &slurmclient.ListOptions{RefreshCache: true}
 	if err := slurmClient.List(ctx, nodeList, opts); err != nil {
+		// Tolerate "Not Found" and "No Content" errors when there are no nodes yet
+		if tolerateError(err) {
+			return nil
+		}
 		return err
 	}
 
@@ -90,6 +94,10 @@ func (r *realSlurmControl) GetNodeNames(ctx context.Context, nodeset *slinkyv1be
 
 	nodeList := &slurmtypes.V0044NodeList{}
 	if err := slurmClient.List(ctx, nodeList); err != nil {
+		// Tolerate "Not Found" and "No Content" errors when there are no nodes yet
+		if tolerateError(err) {
+			return nil, nil
+		}
 		return nil, err
 	}
 

--- a/internal/controller/nodeset/slurmcontrol/slurmcontrol.go
+++ b/internal/controller/nodeset/slurmcontrol/slurmcontrol.go
@@ -549,6 +549,10 @@ func (r *realSlurmControl) GetNodeDeadlines(ctx context.Context, nodeset *slinky
 
 	jobList := &slurmtypes.V0044JobInfoList{}
 	if err := slurmClient.List(ctx, jobList); err != nil {
+		// Tolerate "Not Found" and "No Content" errors when there are no jobs yet
+		if tolerateError(err) {
+			return ts, nil
+		}
 		return nil, err
 	}
 

--- a/internal/controller/nodeset/slurmcontrol/slurmcontrol_test.go
+++ b/internal/controller/nodeset/slurmcontrol/slurmcontrol_test.go
@@ -27,11 +27,11 @@ import (
 	"github.com/SlinkyProject/slurm-client/pkg/object"
 	"github.com/SlinkyProject/slurm-client/pkg/types"
 
-	slinkyv1beta1 "github.com/SlinkyProject/slurm-operator/api/v1beta1"
-	"github.com/SlinkyProject/slurm-operator/internal/clientmap"
-	nodesetutils "github.com/SlinkyProject/slurm-operator/internal/controller/nodeset/utils"
-	"github.com/SlinkyProject/slurm-operator/internal/utils/podinfo"
-	slurmconditions "github.com/SlinkyProject/slurm-operator/pkg/conditions"
+	slinkyv1beta1 "github.com/togethercomputer/slurm-operator/api/v1beta1"
+	"github.com/togethercomputer/slurm-operator/internal/clientmap"
+	nodesetutils "github.com/togethercomputer/slurm-operator/internal/controller/nodeset/utils"
+	"github.com/togethercomputer/slurm-operator/internal/utils/podinfo"
+	slurmconditions "github.com/togethercomputer/slurm-operator/pkg/conditions"
 )
 
 func newNodeSet(name, controllerName string, replicas int32) *slinkyv1beta1.NodeSet {

--- a/internal/controller/nodeset/slurmcontrol/suite_test.go
+++ b/internal/controller/nodeset/slurmcontrol/suite_test.go
@@ -18,8 +18,8 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
-	slinkyv1beta1 "github.com/SlinkyProject/slurm-operator/api/v1beta1"
-	"github.com/SlinkyProject/slurm-operator/internal/utils/testutils"
+	slinkyv1beta1 "github.com/togethercomputer/slurm-operator/api/v1beta1"
+	"github.com/togethercomputer/slurm-operator/internal/utils/testutils"
 	//+kubebuilder:scaffold:imports
 )
 

--- a/internal/controller/nodeset/suite_test.go
+++ b/internal/controller/nodeset/suite_test.go
@@ -22,9 +22,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	"sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
-	slinkyv1beta1 "github.com/SlinkyProject/slurm-operator/api/v1beta1"
-	"github.com/SlinkyProject/slurm-operator/internal/clientmap"
-	"github.com/SlinkyProject/slurm-operator/internal/utils/testutils"
+	slinkyv1beta1 "github.com/togethercomputer/slurm-operator/api/v1beta1"
+	"github.com/togethercomputer/slurm-operator/internal/clientmap"
+	"github.com/togethercomputer/slurm-operator/internal/utils/testutils"
 	//+kubebuilder:scaffold:imports
 )
 

--- a/internal/controller/nodeset/utils/sort.go
+++ b/internal/controller/nodeset/utils/sort.go
@@ -12,10 +12,10 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	podutil "k8s.io/kubernetes/pkg/api/v1/pod"
 
-	slinkyv1beta1 "github.com/SlinkyProject/slurm-operator/api/v1beta1"
-	"github.com/SlinkyProject/slurm-operator/internal/utils/mathutils"
-	"github.com/SlinkyProject/slurm-operator/internal/utils/podutils"
-	"github.com/SlinkyProject/slurm-operator/internal/utils/structutils"
+	slinkyv1beta1 "github.com/togethercomputer/slurm-operator/api/v1beta1"
+	"github.com/togethercomputer/slurm-operator/internal/utils/mathutils"
+	"github.com/togethercomputer/slurm-operator/internal/utils/podutils"
+	"github.com/togethercomputer/slurm-operator/internal/utils/structutils"
 )
 
 // ActivePods type allows custom sorting of pods so a controller can pick the best ones to delete.

--- a/internal/controller/nodeset/utils/sort_test.go
+++ b/internal/controller/nodeset/utils/sort_test.go
@@ -15,7 +15,7 @@ import (
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	slinkyv1beta1 "github.com/SlinkyProject/slurm-operator/api/v1beta1"
+	slinkyv1beta1 "github.com/togethercomputer/slurm-operator/api/v1beta1"
 )
 
 func TestSortingActivePods(t *testing.T) {

--- a/internal/controller/nodeset/utils/utils.go
+++ b/internal/controller/nodeset/utils/utils.go
@@ -17,10 +17,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
-	slinkyv1beta1 "github.com/SlinkyProject/slurm-operator/api/v1beta1"
-	"github.com/SlinkyProject/slurm-operator/internal/builder"
-	"github.com/SlinkyProject/slurm-operator/internal/builder/labels"
-	"github.com/SlinkyProject/slurm-operator/internal/utils/historycontrol"
+	slinkyv1beta1 "github.com/togethercomputer/slurm-operator/api/v1beta1"
+	"github.com/togethercomputer/slurm-operator/internal/builder"
+	"github.com/togethercomputer/slurm-operator/internal/builder/labels"
+	"github.com/togethercomputer/slurm-operator/internal/utils/historycontrol"
 )
 
 // refResolver := refresolver.New(b.client)

--- a/internal/controller/nodeset/utils/utils_test.go
+++ b/internal/controller/nodeset/utils/utils_test.go
@@ -14,8 +14,8 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/ptr"
 
-	slinkyv1beta1 "github.com/SlinkyProject/slurm-operator/api/v1beta1"
-	"github.com/SlinkyProject/slurm-operator/internal/builder/labels"
+	slinkyv1beta1 "github.com/togethercomputer/slurm-operator/api/v1beta1"
+	"github.com/togethercomputer/slurm-operator/internal/builder/labels"
 )
 
 func newNodeSet(name string) *slinkyv1beta1.NodeSet {

--- a/internal/controller/restapi/eventhandler/eventhandler_controller.go
+++ b/internal/controller/restapi/eventhandler/eventhandler_controller.go
@@ -14,9 +14,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
-	slinkyv1beta1 "github.com/SlinkyProject/slurm-operator/api/v1beta1"
-	"github.com/SlinkyProject/slurm-operator/internal/utils/objectutils"
-	"github.com/SlinkyProject/slurm-operator/internal/utils/refresolver"
+	slinkyv1beta1 "github.com/togethercomputer/slurm-operator/api/v1beta1"
+	"github.com/togethercomputer/slurm-operator/internal/utils/objectutils"
+	"github.com/togethercomputer/slurm-operator/internal/utils/refresolver"
 )
 
 func NewControllerEventHandler(reader client.Reader) *ControllerEventHandler {

--- a/internal/controller/restapi/eventhandler/eventhandler_controller_test.go
+++ b/internal/controller/restapi/eventhandler/eventhandler_controller_test.go
@@ -7,7 +7,7 @@ import (
 	"context"
 	"testing"
 
-	slinkyv1beta1 "github.com/SlinkyProject/slurm-operator/api/v1beta1"
+	slinkyv1beta1 "github.com/togethercomputer/slurm-operator/api/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/util/workqueue"
 	"sigs.k8s.io/controller-runtime/pkg/client"

--- a/internal/controller/restapi/eventhandler/eventhandler_secret.go
+++ b/internal/controller/restapi/eventhandler/eventhandler_secret.go
@@ -14,9 +14,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
-	slinkyv1beta1 "github.com/SlinkyProject/slurm-operator/api/v1beta1"
-	"github.com/SlinkyProject/slurm-operator/internal/utils/objectutils"
-	"github.com/SlinkyProject/slurm-operator/internal/utils/refresolver"
+	slinkyv1beta1 "github.com/togethercomputer/slurm-operator/api/v1beta1"
+	"github.com/togethercomputer/slurm-operator/internal/utils/objectutils"
+	"github.com/togethercomputer/slurm-operator/internal/utils/refresolver"
 )
 
 func NewSecretEventHandler(reader client.Reader) *SecretEventHandler {

--- a/internal/controller/restapi/eventhandler/eventhandler_secret_test.go
+++ b/internal/controller/restapi/eventhandler/eventhandler_secret_test.go
@@ -13,7 +13,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
-	"github.com/SlinkyProject/slurm-operator/internal/utils/testutils"
+	"github.com/togethercomputer/slurm-operator/internal/utils/testutils"
 )
 
 func Test_SecretEventHandler_Create(t *testing.T) {

--- a/internal/controller/restapi/eventhandler/utils_test.go
+++ b/internal/controller/restapi/eventhandler/utils_test.go
@@ -9,7 +9,7 @@ import (
 	"k8s.io/client-go/util/workqueue"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
-	slinkyv1beta1 "github.com/SlinkyProject/slurm-operator/api/v1beta1"
+	slinkyv1beta1 "github.com/togethercomputer/slurm-operator/api/v1beta1"
 )
 
 func init() {

--- a/internal/controller/restapi/restapi_controller.go
+++ b/internal/controller/restapi/restapi_controller.go
@@ -21,11 +21,11 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
-	slinkyv1beta1 "github.com/SlinkyProject/slurm-operator/api/v1beta1"
-	"github.com/SlinkyProject/slurm-operator/internal/builder"
-	"github.com/SlinkyProject/slurm-operator/internal/controller/restapi/eventhandler"
-	"github.com/SlinkyProject/slurm-operator/internal/utils/durationstore"
-	"github.com/SlinkyProject/slurm-operator/internal/utils/refresolver"
+	slinkyv1beta1 "github.com/togethercomputer/slurm-operator/api/v1beta1"
+	"github.com/togethercomputer/slurm-operator/internal/builder"
+	"github.com/togethercomputer/slurm-operator/internal/controller/restapi/eventhandler"
+	"github.com/togethercomputer/slurm-operator/internal/utils/durationstore"
+	"github.com/togethercomputer/slurm-operator/internal/utils/refresolver"
 )
 
 const (

--- a/internal/controller/restapi/restapi_controller_test.go
+++ b/internal/controller/restapi/restapi_controller_test.go
@@ -10,8 +10,8 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	slinkyv1beta1 "github.com/SlinkyProject/slurm-operator/api/v1beta1"
-	testutils "github.com/SlinkyProject/slurm-operator/internal/utils/testutils"
+	slinkyv1beta1 "github.com/togethercomputer/slurm-operator/api/v1beta1"
+	testutils "github.com/togethercomputer/slurm-operator/internal/utils/testutils"
 )
 
 var _ = Describe("RestApi Controller", func() {

--- a/internal/controller/restapi/restapi_sync.go
+++ b/internal/controller/restapi/restapi_sync.go
@@ -13,8 +13,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
-	slinkyv1beta1 "github.com/SlinkyProject/slurm-operator/api/v1beta1"
-	"github.com/SlinkyProject/slurm-operator/internal/utils/objectutils"
+	slinkyv1beta1 "github.com/togethercomputer/slurm-operator/api/v1beta1"
+	"github.com/togethercomputer/slurm-operator/internal/utils/objectutils"
 )
 
 type SyncStep struct {

--- a/internal/controller/restapi/restapi_sync_status.go
+++ b/internal/controller/restapi/restapi_sync_status.go
@@ -15,7 +15,7 @@ import (
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
-	slinkyv1beta1 "github.com/SlinkyProject/slurm-operator/api/v1beta1"
+	slinkyv1beta1 "github.com/togethercomputer/slurm-operator/api/v1beta1"
 )
 
 // syncStatus handles determining and updating the status.

--- a/internal/controller/restapi/suite_test.go
+++ b/internal/controller/restapi/suite_test.go
@@ -21,8 +21,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	"sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
-	slinkyv1beta1 "github.com/SlinkyProject/slurm-operator/api/v1beta1"
-	testutils "github.com/SlinkyProject/slurm-operator/internal/utils/testutils"
+	slinkyv1beta1 "github.com/togethercomputer/slurm-operator/api/v1beta1"
+	testutils "github.com/togethercomputer/slurm-operator/internal/utils/testutils"
 	//+kubebuilder:scaffold:imports
 )
 

--- a/internal/controller/slurmclient/slurmclient_controller.go
+++ b/internal/controller/slurmclient/slurmclient_controller.go
@@ -21,10 +21,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
-	slinkyv1beta1 "github.com/SlinkyProject/slurm-operator/api/v1beta1"
-	"github.com/SlinkyProject/slurm-operator/internal/clientmap"
-	"github.com/SlinkyProject/slurm-operator/internal/utils/durationstore"
-	"github.com/SlinkyProject/slurm-operator/internal/utils/refresolver"
+	slinkyv1beta1 "github.com/togethercomputer/slurm-operator/api/v1beta1"
+	"github.com/togethercomputer/slurm-operator/internal/clientmap"
+	"github.com/togethercomputer/slurm-operator/internal/utils/durationstore"
+	"github.com/togethercomputer/slurm-operator/internal/utils/refresolver"
 )
 
 const (

--- a/internal/controller/slurmclient/slurmclient_controller_test.go
+++ b/internal/controller/slurmclient/slurmclient_controller_test.go
@@ -11,8 +11,8 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 
-	slinkyv1beta1 "github.com/SlinkyProject/slurm-operator/api/v1beta1"
-	"github.com/SlinkyProject/slurm-operator/internal/utils/testutils"
+	slinkyv1beta1 "github.com/togethercomputer/slurm-operator/api/v1beta1"
+	"github.com/togethercomputer/slurm-operator/internal/utils/testutils"
 )
 
 var _ = Describe("SlurmClient Controller", func() {

--- a/internal/controller/slurmclient/slurmclient_sync.go
+++ b/internal/controller/slurmclient/slurmclient_sync.go
@@ -21,10 +21,10 @@ import (
 	slurmobject "github.com/SlinkyProject/slurm-client/pkg/object"
 	slurmtypes "github.com/SlinkyProject/slurm-client/pkg/types"
 
-	slinkyv1beta1 "github.com/SlinkyProject/slurm-operator/api/v1beta1"
-	"github.com/SlinkyProject/slurm-operator/internal/builder"
-	"github.com/SlinkyProject/slurm-operator/internal/controller/nodeset/eventhandler"
-	"github.com/SlinkyProject/slurm-operator/internal/controller/token/slurmjwt"
+	slinkyv1beta1 "github.com/togethercomputer/slurm-operator/api/v1beta1"
+	"github.com/togethercomputer/slurm-operator/internal/builder"
+	"github.com/togethercomputer/slurm-operator/internal/controller/nodeset/eventhandler"
+	"github.com/togethercomputer/slurm-operator/internal/controller/token/slurmjwt"
 )
 
 // Sync implements control logic for synchronizing a Restapi.

--- a/internal/controller/slurmclient/suite_test.go
+++ b/internal/controller/slurmclient/suite_test.go
@@ -21,11 +21,11 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	"sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
-	slinkyv1beta1 "github.com/SlinkyProject/slurm-operator/api/v1beta1"
-	"github.com/SlinkyProject/slurm-operator/internal/clientmap"
-	"github.com/SlinkyProject/slurm-operator/internal/controller/controller"
-	"github.com/SlinkyProject/slurm-operator/internal/controller/restapi"
-	"github.com/SlinkyProject/slurm-operator/internal/utils/testutils"
+	slinkyv1beta1 "github.com/togethercomputer/slurm-operator/api/v1beta1"
+	"github.com/togethercomputer/slurm-operator/internal/clientmap"
+	"github.com/togethercomputer/slurm-operator/internal/controller/controller"
+	"github.com/togethercomputer/slurm-operator/internal/controller/restapi"
+	"github.com/togethercomputer/slurm-operator/internal/utils/testutils"
 	//+kubebuilder:scaffold:imports
 )
 

--- a/internal/controller/token/slurmjwt/token.go
+++ b/internal/controller/token/slurmjwt/token.go
@@ -8,7 +8,7 @@ import (
 	"math"
 	"time"
 
-	"github.com/SlinkyProject/slurm-operator/internal/utils/mathutils"
+	"github.com/togethercomputer/slurm-operator/internal/utils/mathutils"
 	jwt "github.com/golang-jwt/jwt/v5"
 	"k8s.io/apimachinery/pkg/util/uuid"
 )

--- a/internal/controller/token/slurmjwt/token_test.go
+++ b/internal/controller/token/slurmjwt/token_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/SlinkyProject/slurm-operator/internal/utils/crypto"
+	"github.com/togethercomputer/slurm-operator/internal/utils/crypto"
 )
 
 func newSignedToken(signingKey []byte) string {

--- a/internal/controller/token/suite_test.go
+++ b/internal/controller/token/suite_test.go
@@ -19,8 +19,8 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
-	slinkyv1beta1 "github.com/SlinkyProject/slurm-operator/api/v1beta1"
-	"github.com/SlinkyProject/slurm-operator/internal/utils/testutils"
+	slinkyv1beta1 "github.com/togethercomputer/slurm-operator/api/v1beta1"
+	"github.com/togethercomputer/slurm-operator/internal/utils/testutils"
 	// +kubebuilder:scaffold:imports
 )
 

--- a/internal/controller/token/token_controller.go
+++ b/internal/controller/token/token_controller.go
@@ -19,10 +19,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
-	slinkyv1beta1 "github.com/SlinkyProject/slurm-operator/api/v1beta1"
-	"github.com/SlinkyProject/slurm-operator/internal/builder"
-	"github.com/SlinkyProject/slurm-operator/internal/utils/durationstore"
-	"github.com/SlinkyProject/slurm-operator/internal/utils/refresolver"
+	slinkyv1beta1 "github.com/togethercomputer/slurm-operator/api/v1beta1"
+	"github.com/togethercomputer/slurm-operator/internal/builder"
+	"github.com/togethercomputer/slurm-operator/internal/utils/durationstore"
+	"github.com/togethercomputer/slurm-operator/internal/utils/refresolver"
 )
 
 const (

--- a/internal/controller/token/token_controller_test.go
+++ b/internal/controller/token/token_controller_test.go
@@ -9,8 +9,8 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	slinkyv1beta1 "github.com/SlinkyProject/slurm-operator/api/v1beta1"
-	"github.com/SlinkyProject/slurm-operator/internal/utils/testutils"
+	slinkyv1beta1 "github.com/togethercomputer/slurm-operator/api/v1beta1"
+	"github.com/togethercomputer/slurm-operator/internal/utils/testutils"
 )
 
 var _ = Describe("Token Controller", func() {

--- a/internal/controller/token/token_sync.go
+++ b/internal/controller/token/token_sync.go
@@ -14,9 +14,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
-	slinkyv1beta1 "github.com/SlinkyProject/slurm-operator/api/v1beta1"
-	"github.com/SlinkyProject/slurm-operator/internal/controller/token/slurmjwt"
-	"github.com/SlinkyProject/slurm-operator/internal/utils/objectutils"
+	slinkyv1beta1 "github.com/togethercomputer/slurm-operator/api/v1beta1"
+	"github.com/togethercomputer/slurm-operator/internal/controller/token/slurmjwt"
+	"github.com/togethercomputer/slurm-operator/internal/utils/objectutils"
 )
 
 type SyncStep struct {

--- a/internal/controller/token/token_sync_status.go
+++ b/internal/controller/token/token_sync_status.go
@@ -15,10 +15,10 @@ import (
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
-	slinkyv1beta1 "github.com/SlinkyProject/slurm-operator/api/v1beta1"
-	"github.com/SlinkyProject/slurm-operator/internal/controller/token/slurmjwt"
-	"github.com/SlinkyProject/slurm-operator/internal/utils/objectutils"
-	"github.com/SlinkyProject/slurm-operator/internal/utils/structutils"
+	slinkyv1beta1 "github.com/togethercomputer/slurm-operator/api/v1beta1"
+	"github.com/togethercomputer/slurm-operator/internal/controller/token/slurmjwt"
+	"github.com/togethercomputer/slurm-operator/internal/utils/objectutils"
+	"github.com/togethercomputer/slurm-operator/internal/utils/structutils"
 )
 
 // syncStatus handles determining and updating the status.

--- a/internal/controller/token/token_sync_status_test.go
+++ b/internal/controller/token/token_sync_status_test.go
@@ -9,7 +9,7 @@ import (
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	slinkyv1beta1 "github.com/SlinkyProject/slurm-operator/api/v1beta1"
+	slinkyv1beta1 "github.com/togethercomputer/slurm-operator/api/v1beta1"
 )
 
 func TestTokenReconciler_syncStatus(t *testing.T) {

--- a/internal/utils/crypto/hash.go
+++ b/internal/utils/crypto/hash.go
@@ -8,7 +8,7 @@ import (
 	"fmt"
 	"sort"
 
-	"github.com/SlinkyProject/slurm-operator/internal/utils/structutils"
+	"github.com/togethercomputer/slurm-operator/internal/utils/structutils"
 )
 
 func CheckSum(b []byte) string {

--- a/internal/utils/objectutils/delete.go
+++ b/internal/utils/objectutils/delete.go
@@ -16,7 +16,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
-	slinkyv1beta1 "github.com/SlinkyProject/slurm-operator/api/v1beta1"
+	slinkyv1beta1 "github.com/togethercomputer/slurm-operator/api/v1beta1"
 )
 
 func DeleteObject(c client.Client, ctx context.Context, newObj client.Object) error {

--- a/internal/utils/objectutils/delete_test.go
+++ b/internal/utils/objectutils/delete_test.go
@@ -7,7 +7,7 @@ import (
 	"context"
 	"testing"
 
-	slinkyv1beta1 "github.com/SlinkyProject/slurm-operator/api/v1beta1"
+	slinkyv1beta1 "github.com/togethercomputer/slurm-operator/api/v1beta1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/internal/utils/objectutils/patch.go
+++ b/internal/utils/objectutils/patch.go
@@ -17,8 +17,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
-	slinkyv1beta1 "github.com/SlinkyProject/slurm-operator/api/v1beta1"
-	"github.com/SlinkyProject/slurm-operator/internal/utils/structutils"
+	slinkyv1beta1 "github.com/togethercomputer/slurm-operator/api/v1beta1"
+	"github.com/togethercomputer/slurm-operator/internal/utils/structutils"
 )
 
 func SyncObject(c client.Client, ctx context.Context, newObj client.Object, shouldUpdate bool) error {

--- a/internal/utils/objectutils/patch_test.go
+++ b/internal/utils/objectutils/patch_test.go
@@ -7,7 +7,7 @@ import (
 	"context"
 	"testing"
 
-	slinkyv1beta1 "github.com/SlinkyProject/slurm-operator/api/v1beta1"
+	slinkyv1beta1 "github.com/togethercomputer/slurm-operator/api/v1beta1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/internal/utils/podutils/pod.go
+++ b/internal/utils/podutils/pod.go
@@ -8,7 +8,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	podutil "k8s.io/kubernetes/pkg/api/v1/pod"
 
-	slinkyv1beta1 "github.com/SlinkyProject/slurm-operator/api/v1beta1"
+	slinkyv1beta1 "github.com/togethercomputer/slurm-operator/api/v1beta1"
 )
 
 // IsPodCordon returns true if and only if the delete annotation is nodeset to true.

--- a/internal/utils/refresolver/refresolver.go
+++ b/internal/utils/refresolver/refresolver.go
@@ -11,8 +11,8 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	slinkyv1beta1 "github.com/SlinkyProject/slurm-operator/api/v1beta1"
-	"github.com/SlinkyProject/slurm-operator/internal/utils/objectutils"
+	slinkyv1beta1 "github.com/togethercomputer/slurm-operator/api/v1beta1"
+	"github.com/togethercomputer/slurm-operator/internal/utils/objectutils"
 )
 
 type RefResolver struct {

--- a/internal/utils/refresolver/refresolver_test.go
+++ b/internal/utils/refresolver/refresolver_test.go
@@ -7,8 +7,8 @@ import (
 	"context"
 	"testing"
 
-	slinkyv1beta1 "github.com/SlinkyProject/slurm-operator/api/v1beta1"
-	"github.com/SlinkyProject/slurm-operator/internal/utils/objectutils"
+	slinkyv1beta1 "github.com/togethercomputer/slurm-operator/api/v1beta1"
+	"github.com/togethercomputer/slurm-operator/internal/utils/objectutils"
 	corev1 "k8s.io/api/core/v1"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/internal/utils/testutils/helpers.go
+++ b/internal/utils/testutils/helpers.go
@@ -11,7 +11,7 @@ import (
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	slinkyv1beta1 "github.com/SlinkyProject/slurm-operator/api/v1beta1"
+	slinkyv1beta1 "github.com/togethercomputer/slurm-operator/api/v1beta1"
 )
 
 const Timeout = 30 * time.Second

--- a/internal/utils/testutils/helpers_test.go
+++ b/internal/utils/testutils/helpers_test.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"testing"
 
-	slinkyv1beta1 "github.com/SlinkyProject/slurm-operator/api/v1beta1"
+	slinkyv1beta1 "github.com/togethercomputer/slurm-operator/api/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"

--- a/internal/webhook/accounting_webhook.go
+++ b/internal/webhook/accounting_webhook.go
@@ -14,7 +14,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
-	slinkyv1beta1 "github.com/SlinkyProject/slurm-operator/api/v1beta1"
+	slinkyv1beta1 "github.com/togethercomputer/slurm-operator/api/v1beta1"
 )
 
 // TODO(user): EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!

--- a/internal/webhook/controller_webhook.go
+++ b/internal/webhook/controller_webhook.go
@@ -22,8 +22,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
-	slinkyv1beta1 "github.com/SlinkyProject/slurm-operator/api/v1beta1"
-	"github.com/SlinkyProject/slurm-operator/internal/utils/structutils"
+	slinkyv1beta1 "github.com/togethercomputer/slurm-operator/api/v1beta1"
+	"github.com/togethercomputer/slurm-operator/internal/utils/structutils"
 )
 
 // TODO(user): EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!

--- a/internal/webhook/loginset_webhook.go
+++ b/internal/webhook/loginset_webhook.go
@@ -14,7 +14,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
-	slinkyv1beta1 "github.com/SlinkyProject/slurm-operator/api/v1beta1"
+	slinkyv1beta1 "github.com/togethercomputer/slurm-operator/api/v1beta1"
 )
 
 // TODO(user): EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!

--- a/internal/webhook/nodeset_webhook.go
+++ b/internal/webhook/nodeset_webhook.go
@@ -15,7 +15,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
-	slinkyv1beta1 "github.com/SlinkyProject/slurm-operator/api/v1beta1"
+	slinkyv1beta1 "github.com/togethercomputer/slurm-operator/api/v1beta1"
 )
 
 // TODO(user): EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!

--- a/internal/webhook/restapi_webhook.go
+++ b/internal/webhook/restapi_webhook.go
@@ -14,7 +14,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
-	slinkyv1beta1 "github.com/SlinkyProject/slurm-operator/api/v1beta1"
+	slinkyv1beta1 "github.com/togethercomputer/slurm-operator/api/v1beta1"
 )
 
 // TODO(user): EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!

--- a/internal/webhook/token_webhook.go
+++ b/internal/webhook/token_webhook.go
@@ -14,7 +14,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
-	slinkyv1beta1 "github.com/SlinkyProject/slurm-operator/api/v1beta1"
+	slinkyv1beta1 "github.com/togethercomputer/slurm-operator/api/v1beta1"
 )
 
 // TODO(user): EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!

--- a/internal/webhook/webhook_suite_test.go
+++ b/internal/webhook/webhook_suite_test.go
@@ -27,8 +27,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/metrics/server"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 
-	slinkyv1beta1 "github.com/SlinkyProject/slurm-operator/api/v1beta1"
-	"github.com/SlinkyProject/slurm-operator/internal/utils/testutils"
+	slinkyv1beta1 "github.com/togethercomputer/slurm-operator/api/v1beta1"
+	"github.com/togethercomputer/slurm-operator/internal/utils/testutils"
 )
 
 // These tests use Ginkgo (BDD-style Go testing framework). Refer to

--- a/pkg/taints/taints.go
+++ b/pkg/taints/taints.go
@@ -4,7 +4,7 @@
 package taints
 
 import (
-	slinkyv1beta1 "github.com/SlinkyProject/slurm-operator/api/v1beta1"
+	slinkyv1beta1 "github.com/togethercomputer/slurm-operator/api/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 )
 


### PR DESCRIPTION
Summary

- Rebase our slurm-operator fork onto upstream Slinky v1.0 (v1beta1 APIs).

- Re‑introduce Together‑specific behavior that was in PR #13, adapted to the new 1.0 architecture.

**Key changes**
- Node cordon signal
Add slinky.slurm.net/node-cordon annotation constant.
Implement updateNodeCordonAnnotation / isNodeCordoned logic in nodeset controller so K8s Nodes are marked when Slurm nodes are drained/undrained.
Keep using upstream pod‑level annotations (AnnotationPodCordon, AnnotationPodDeletionCost) from v1.0.
- Login support
Add login section to helm/slurm/values.yaml (image, resources, nodeSelector, affinity, tolerations, extra volumes).
Add login helpers in _slurm.tpl.
Add helm/slurm/templates/login/login-deployment.yaml and login-service.yaml to deploy the login pod.
- Helm configuration knobs
Extend Slurm chart values to support:
Additional tolerations for controller/accounting/restapi where needed.
shmSize and persistence.existingDataClaims for compute NodeSets (e.g. /data, /scratch).
Wire these values into the corresponding templates.
- Operator chart / RBAC
Add .Values.operator.tolerations and .Values.operator.affinity to the operator Deployment.
Ensure RBAC includes update on resources required by new behavior (e.g. nodes).
- Module / wiring
Set module path to github.com/togethercomputer/slurm-operator and adjust imports so tcloud can depend on this fork cleanly.


#### Verify
Images in https://github.com/orgs/togethercomputer/packages/container/package/slurm-operator
