### PR TITLE
[TCL-2751] Slinky v1.0: fix chart rendering, reconfigure deadlock, login auth, and SLURM_CONF_SERVER

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -137,3 +137,4 @@ values-*.yaml
 .helm_ls_cache
 docs/build/html
 *debug_bin*
+test-values.yaml

--- a/helm/slurm/templates/_helpers.tpl
+++ b/helm/slurm/templates/_helpers.tpl
@@ -161,3 +161,14 @@ Ref: https://github.com/helm/helm/issues/11376#issuecomment-1256831105
 {{- end -}}
 {{- mulf (float64 $value) $unit -}}
 {{- end -}}
+
+{{/*
+Default pod dnsConfig snippet.
+
+We keep this as a helper so templates can include it consistently.
+*/}}
+{{- define "slurm.dnsConfig" -}}
+options:
+  - name: ndots
+    value: "1"
+{{- end -}}

--- a/helm/slurm/templates/login/login-deployment.yaml
+++ b/helm/slurm/templates/login/login-deployment.yaml
@@ -61,6 +61,8 @@ spec:
           value: {{ include "slurm.fullname" . }}
         - name: SLURM_CONF_SERVER
           value: {{ include "slurm.fullname" . }}.{{ include "slurm.namespace" . }}.svc.cluster.local
+        - name: SACKD_OPTIONS
+          value: "--conf-server {{ include "slurm.fullname" . }}-controller.{{ include "slurm.namespace" . }}:6817"
         volumeMounts:
         - name: slurm-config
           mountPath: /etc/slurm

--- a/helm/slurm/templates/login/login-deployment.yaml
+++ b/helm/slurm/templates/login/login-deployment.yaml
@@ -60,7 +60,7 @@ spec:
         - name: SLURM_CLUSTER_NAME
           value: {{ include "slurm.fullname" . }}
         - name: SLURM_CONF_SERVER
-          value: {{ include "slurm.fullname" . }}.{{ include "slurm.namespace" . }}.svc.cluster.local
+          value: {{ include "slurm.fullname" . }}-controller.{{ include "slurm.namespace" . }}.svc.cluster.local
         - name: SACKD_OPTIONS
           value: "--conf-server {{ include "slurm.fullname" . }}-controller.{{ include "slurm.namespace" . }}:6817"
         volumeMounts:
@@ -82,8 +82,15 @@ spec:
         {{- end }}
       volumes:
       - name: slurm-config
-        configMap:
-          name: {{ include "slurm.fullname" . }}-config
+        projected:
+          defaultMode: 0600
+          sources:
+          - configMap:
+              name: {{ include "slurm.fullname" . }}-config
+          - secret:
+              name: {{ include "slurm.fullname" . }}-auth-slurm
+          - secret:
+              name: {{ include "slurm.fullname" . }}-auth-jwths256
       {{- if .Values.login.sharedMemorySize }}
       - name: dshm
         emptyDir:

--- a/helm/slurm/templates/login/login-deployment.yaml
+++ b/helm/slurm/templates/login/login-deployment.yaml
@@ -32,26 +32,6 @@ spec:
       enableServiceLinks: false
       dnsConfig:
         {{- include "slurm.dnsConfig" . | nindent 8 }}
-      initContainers:
-        - name: init
-          image: {{ include "slurm.authcred.imageRef" . }}
-          imagePullPolicy: {{ .Values.authcred.imagePullPolicy | default (include "slurm.imagePullPolicy" .) }}
-          {{- with .Values.authcred.resources }}
-          resources:
-            {{- toYaml . | nindent 12 }}
-          {{- end }}{{- /* with .Values.authcred.resources */}}
-          env:
-            - name: SLURM_USER
-              value: {{ include "slurm.user" . }}
-          command:
-            - bash
-            - -c
-            - |
-              {{- range .Files.Lines "scripts/init.sh" }}
-              {{ . }}
-              {{- end }}{{- /* range .Files.Lines "scripts/init.sh" */}}
-          volumeMounts:
-            {{- include "slurm.init.volumeMounts" . | nindent 12 }}
       {{- with .Values.login.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/helm/slurm/templates/login/login-deployment.yaml
+++ b/helm/slurm/templates/login/login-deployment.yaml
@@ -59,7 +59,7 @@ spec:
         env:
         - name: SLURM_CLUSTER_NAME
           value: {{ include "slurm.fullname" . }}
-        - name: SLURM_CONF_SERVER
+        - name: SLURM_CONF_SERVER  # TCL-4403: must use -controller service name
           value: {{ include "slurm.fullname" . }}-controller.{{ include "slurm.namespace" . }}.svc.cluster.local
         - name: SACKD_OPTIONS
           value: "--conf-server {{ include "slurm.fullname" . }}-controller.{{ include "slurm.namespace" . }}:6817"
@@ -81,7 +81,7 @@ spec:
           {{- end }}
         {{- end }}
       volumes:
-      - name: slurm-config
+      - name: slurm-config  # TCL-4402: projected volume with auth secrets at mode 0600
         projected:
           defaultMode: 0600
           sources:

--- a/internal/builder/scripts/reconfigure.sh
+++ b/internal/builder/scripts/reconfigure.sh
@@ -27,6 +27,7 @@ function main() {
 
 	# Initialize lastHash to avoid a spurious reconfigure on startup.
 	# slurmctld may still be initializing and an early SIGHUP can deadlock it.
+	# TCL-4401
 	lastHash="$(getHash)"
 
 	echo "[$(date)] Start '$SLURM_DIR' polling (initial hash captured)"

--- a/internal/builder/scripts/reconfigure.sh
+++ b/internal/builder/scripts/reconfigure.sh
@@ -25,7 +25,11 @@ function main() {
 	local lastHash=""
 	local newHash=""
 
-	echo "[$(date)] Start '$SLURM_DIR' polling"
+	# Initialize lastHash to avoid a spurious reconfigure on startup.
+	# slurmctld may still be initializing and an early SIGHUP can deadlock it.
+	lastHash="$(getHash)"
+
+	echo "[$(date)] Start '$SLURM_DIR' polling (initial hash captured)"
 	while true; do
 		newHash="$(getHash)"
 		if [ "$newHash" != "$lastHash" ]; then


### PR DESCRIPTION
## Summary

Fixes 6 issues blocking Slinky v1.0 Slurm clusters from provisioning correctly.

### Chart rendering fixes
- **Add `slurm.dnsConfig` helper** (TCL-4404) — login template called undefined helper
- **Remove broken `authcred` initContainer** (TCL-4404) — referenced templates from upstream that don't exist in our fork
- **Add `SACKD_OPTIONS` env var** (TCL-4408) — login entrypoint needs this for sackd to connect to controller

### Reconfigure sidecar deadlock fix
- **Initialize `lastHash` in `reconfigure.sh`** (TCL-4401) — the sidecar started with `lastHash=""`, always triggering `scontrol reconfigure` on startup, which deadlocks slurmctld 25.11.2. Now captures initial hash before polling.

### Login auth fixes
- **Mount auth secrets as projected volume** (TCL-4402) — login Deployment only mounted configmap, missing `slurm-auth-slurm` and `slurm-auth-jwths256` secrets needed by sackd for bootstrap auth. Uses projected volume with `defaultMode: 0600`.
- **Fix `SLURM_CONF_SERVER` env var** (TCL-4403) — pointed to `slurm.slurm.svc` (doesn't exist), changed to `slurm-controller.slurm.svc`.

## Linear
- [TCL-4401](https://linear.app/together-ai/issue/TCL-4401), [TCL-4402](https://linear.app/together-ai/issue/TCL-4402), [TCL-4403](https://linear.app/together-ai/issue/TCL-4403), [TCL-4404](https://linear.app/together-ai/issue/TCL-4404), [TCL-4408](https://linear.app/together-ai/issue/TCL-4408)

## Test
- `helm template` passes
- Staging cluster reached Ready with all fixes (cluster `t-f7eeaf3a`)"