### PR TITLE
[TCL-4609] Fix login pod permissions: split config (644) from auth keys (600)

### DIFF
--- a/helm/slurm/templates/login/login-deployment.yaml
+++ b/helm/slurm/templates/login/login-deployment.yaml
@@ -44,6 +44,16 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      initContainers:
+      - name: fix-perms
+        image: "docker.io/library/alpine:3.19"
+        command: ["sh", "-c", "set -e && cp /mnt/slurm/* /etc/slurm/ && chmod 644 /etc/slurm/*.conf && chmod 600 /etc/slurm/*.key && chown -R root:root /etc/slurm/"]
+        volumeMounts:
+        - name: slurm-config-projected
+          mountPath: /mnt/slurm
+          readOnly: true
+        - name: slurm-config
+          mountPath: /etc/slurm
       containers:
       - name: login
         image: "{{ .Values.login.image.repository }}:{{ .Values.login.image.tag }}"
@@ -81,7 +91,9 @@ spec:
           {{- end }}
         {{- end }}
       volumes:
-      - name: slurm-config  # TCL-4402: projected volume with auth secrets at mode 0600
+      - name: slurm-config
+        emptyDir: {}
+      - name: slurm-config-projected  # TCL-4402: projected volume, copied by initContainer with split permissions
         projected:
           defaultMode: 0600
           sources:


### PR DESCRIPTION
## Summary

Non-root LDAP users on Slinky v1.0 login pods get "Permission denied" when running `sinfo` because `slurm.conf` is 0600 (owner-only). Discovered on Meshy's B200 cluster — first customer on v1.0.

## Root Cause

TCL-4402 added a projected volume combining ConfigMap + auth Secrets with `defaultMode: 0600`. Correct for auth keys (`slurm.key`, `jwt_hs256.key`) but made config files (`slurm.conf`, `gres.conf`, `cgroup.conf`) also 0600.

## Fix

Add `fix-perms` initContainer to login deployment that:
1. Copies files from the projected volume (read-only) to an emptyDir
2. Sets config files to 0644 (world-readable)
3. Sets auth keys to 0600 (owner-only)

Same pattern used by the accounting pod fix.

## Hotfix

Already applied to Meshy's live cluster via `kubectl patch deployment`.

## Linear
- [TCL-4609](https://linear.app/together-ai/issue/TCL-4609)