### PR TITLE
fix: use login image for fix-perms initContainer to avoid Docker Hub rate limits

### DIFF
--- a/helm/slurm/templates/login/login-deployment.yaml
+++ b/helm/slurm/templates/login/login-deployment.yaml
@@ -46,7 +46,7 @@ spec:
       {{- end }}
       initContainers:
       - name: fix-perms
-        image: "docker.io/library/alpine:3.19"
+        image: "{{ .Values.login.image.repository }}:{{ .Values.login.image.tag }}"
         command: ["sh", "-c", "set -e && cp /mnt/slurm/* /etc/slurm/ && chmod 644 /etc/slurm/*.conf && chmod 600 /etc/slurm/*.key && chown -R root:root /etc/slurm/"]
         volumeMounts:
         - name: slurm-config-projected


### PR DESCRIPTION
## Summary
- Swap `docker.io/library/alpine:3.19` → `{{ .Values.login.image.repository }}:{{ .Values.login.image.tag }}` for the `fix-perms` initContainer in the login deployment
- The alpine image hits Docker Hub's unauthenticated rate limit (`429 Too Many Requests`) on large clusters where many nodes pull images simultaneously
- The login image is always already cached on the node (pulled for the main container), so this eliminates the extra pull entirely

## Context
Discovered during Suno's 128-node Slinky v1.0 rollout. The login pod couldn't start because the init container failed to pull `alpine:3.19` due to rate limiting. The slurm-login image (Ubuntu-based) has all the tools the init container needs (`cp`, `chmod`, `chown`).

## Test plan
- [x] `helm template` renders correctly with the login image in both init and main containers
- [x] Manually tested on Suno's production cluster — login pod starts, sinfo works, permissions correct (644 for configs, 600 for keys)