### PR TITLE
TCL-5107: feat: add initScriptLogin and initScriptNodes values

### DIFF
--- a/helm/slurm/templates/controller/_helpers.tpl
+++ b/helm/slurm/templates/controller/_helpers.tpl
@@ -105,3 +105,17 @@ Worker epilog slurmctld scripts.
 {{- define "slurm.controller.epilogSlurmctldName" -}}
 {{- printf "%s-epilog-slurmctld-scripts" (include "slurm.fullname" .) -}}
 {{- end }}
+
+{{/*
+Init script for login nodes.
+*/}}
+{{- define "slurm.initScriptLoginName" -}}
+{{- printf "%s-init-script-login" (include "slurm.fullname" .) -}}
+{{- end }}
+
+{{/*
+Init script for compute nodes.
+*/}}
+{{- define "slurm.initScriptNodesName" -}}
+{{- printf "%s-init-script-nodes" (include "slurm.fullname" .) -}}
+{{- end }}

--- a/helm/slurm/templates/login/init-script-configmap.yaml
+++ b/helm/slurm/templates/login/init-script-configmap.yaml
@@ -1,0 +1,17 @@
+{{- /*
+SPDX-FileCopyrightText: Copyright (C) SchedMD LLC.
+SPDX-License-Identifier: Apache-2.0
+*/}}
+
+{{- if .Values.initScriptLogin -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "slurm.initScriptLoginName" . }}
+  namespace: {{ include "slurm.namespace" . }}
+  labels:
+    {{- include "slurm.labels" . | nindent 4 }}
+data:
+  init.sh: |
+    {{- .Values.initScriptLogin | nindent 4 }}
+{{- end }}{{- /* if .Values.initScriptLogin */}}

--- a/helm/slurm/templates/login/login-deployment.yaml
+++ b/helm/slurm/templates/login/login-deployment.yaml
@@ -80,6 +80,11 @@ spec:
         - name: dshm
           mountPath: /dev/shm
         {{- end }}
+        {{- if .Values.initScriptLogin }}
+        - name: init-script
+          mountPath: /root/init.sh
+          subPath: init.sh
+        {{- end }}
         {{- range .Values.login.extraVolumeMounts }}
         - name: {{ .name }}
           mountPath: {{ .mountPath }}
@@ -108,6 +113,12 @@ spec:
         emptyDir:
           medium: Memory
           sizeLimit: {{ .Values.login.sharedMemorySize }}
+      {{- end }}
+      {{- if .Values.initScriptLogin }}
+      - name: init-script
+        configMap:
+          name: {{ include "slurm.initScriptLoginName" . }}
+          defaultMode: 0755
       {{- end }}
       {{- range .Values.login.extraVolumes }}
       - name: {{ .name }}

--- a/helm/slurm/templates/nodeset/init-script-configmap.yaml
+++ b/helm/slurm/templates/nodeset/init-script-configmap.yaml
@@ -1,0 +1,17 @@
+{{- /*
+SPDX-FileCopyrightText: Copyright (C) SchedMD LLC.
+SPDX-License-Identifier: Apache-2.0
+*/}}
+
+{{- if .Values.initScriptNodes -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "slurm.initScriptNodesName" . }}
+  namespace: {{ include "slurm.namespace" . }}
+  labels:
+    {{- include "slurm.labels" . | nindent 4 }}
+data:
+  init.sh: |
+    {{- .Values.initScriptNodes | nindent 4 }}
+{{- end }}{{- /* if .Values.initScriptNodes */}}

--- a/helm/slurm/templates/nodeset/nodeset-cr.yaml
+++ b/helm/slurm/templates/nodeset/nodeset-cr.yaml
@@ -37,6 +37,17 @@ SPDX-License-Identifier: Apache-2.0
   {{- $_ := set $podSpec "volumes" $volumes -}}
   {{- $_ := set $nodeset.slurmd "volumeMounts" $volumeMounts -}}
 {{- end }}
+{{- /* Add init script volume and mount for compute nodes (Together addition) */}}
+{{- if $.Values.initScriptNodes }}
+  {{- $volumes := $podSpec.volumes | default list -}}
+  {{- $initScriptVolume := dict "name" "init-script" "configMap" (dict "name" (include "slurm.initScriptNodesName" $) "defaultMode" 0755) -}}
+  {{- $volumes = append $volumes $initScriptVolume -}}
+  {{- $_ := set $podSpec "volumes" $volumes -}}
+  {{- $volumeMounts := $nodeset.slurmd.volumeMounts | default list -}}
+  {{- $initScriptVolumeMount := dict "name" "init-script" "mountPath" "/root/init.sh" "subPath" "init.sh" -}}
+  {{- $volumeMounts = append $volumeMounts $initScriptVolumeMount -}}
+  {{- $_ := set $nodeset.slurmd "volumeMounts" $volumeMounts -}}
+{{- end }}
 {{- $podTemplate := dict "metadata" $podMetadata "spec" $podSpec -}}
 {{- if $nodeset.useResourceLimits }}
   {{- $envLimts := list (dict "name" "POD_CPUS" "value" (include "slurm.worker.podCpus" $nodeset.slurmd | toString)) (dict "name" "POD_MEMORY" "value" (include "slurm.worker.podMemory" $nodeset.slurmd | toString)) -}}

--- a/helm/slurm/values.yaml
+++ b/helm/slurm/values.yaml
@@ -118,6 +118,24 @@ epilogScripts: {}
   #   set -euo pipefail
   #   exit 0
 
+# -- (string) Init script mounted to /root/init.sh on all login nodes.
+# WARNING: The script must include a shebang (!) so it can be executed correctly.
+# Ref: https://en.wikipedia.org/wiki/Shebang_(Unix)
+initScriptLogin: null
+  # |
+  #   #!/usr/bin/env bash
+  #   set -euo pipefail
+  #   echo "Login node init"
+
+# -- (string) Init script mounted to /root/init.sh on all NodeSets (compute nodes).
+# WARNING: The script must include a shebang (!) so it can be executed correctly.
+# Ref: https://en.wikipedia.org/wiki/Shebang_(Unix)
+initScriptNodes: null
+  # |
+  #   #!/usr/bin/env bash
+  #   set -euo pipefail
+  #   echo "Compute node init"
+
 # Slurm controller (slurmctld) configuration.
 controller:
   # -- Configures this component as external (not in Kubernetes).


### PR DESCRIPTION
## Summary
- Add `initScriptLogin` Helm value to mount custom init scripts to `/root/init.sh` on login nodes
- Add `initScriptNodes` Helm value to mount custom init scripts to `/root/init.sh` on compute nodes
- Scripts are stored in ConfigMaps and mounted with mode 0755

## Test plan
- [ ] Deploy with `initScriptLogin` set and verify script appears at `/root/init.sh` on login pods
- [ ] Deploy with `initScriptNodes` set and verify script appears at `/root/init.sh` on compute pods
- [ ] Verify scripts are executable (mode 0755)