### PR TITLE
feat: add system defaults to buildSlurmConf (TCL-5588)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -138,3 +138,6 @@ values-*.yaml
 docs/build/html
 *debug_bin*
 test-values.yaml
+
+# codemogger db
+.codemogger/

--- a/internal/builder/controller_config.go
+++ b/internal/builder/controller_config.go
@@ -276,6 +276,7 @@ func buildSlurmConf(
 	conf.AddProperty(config.NewProperty("HealthCheckInterval", 60))
 	conf.AddProperty(config.NewProperty("HealthCheckNodeState", "ANY"))
 	conf.AddProperty(config.NewProperty("HealthCheckProgram", "/usr/bin/gpu_healthcheck.sh"))
+	conf.AddProperty(config.NewProperty("JobRequeue", 0))
 
 	extraConf := controller.Spec.ExtraConf
 	conf.AddProperty(config.NewPropertyRaw("#"))

--- a/internal/builder/controller_config.go
+++ b/internal/builder/controller_config.go
@@ -291,6 +291,7 @@ func buildCgroupConf() string {
 
 	conf.AddProperty(config.NewProperty("CgroupPlugin", "cgroup/v2"))
 	conf.AddProperty(config.NewProperty("IgnoreSystemd", "yes"))
+	conf.AddProperty(config.NewProperty("ConstrainRAMSpace", "yes"))
 
 	return conf.Build()
 }

--- a/internal/builder/controller_config.go
+++ b/internal/builder/controller_config.go
@@ -270,6 +270,13 @@ func buildSlurmConf(
 		conf.AddProperty(config.NewPropertyRaw(partitionLineRendered))
 	}
 
+	conf.AddProperty(config.NewPropertyRaw("#"))
+	conf.AddProperty(config.NewPropertyRaw("### SYSTEM DEFAULTS ###"))
+	conf.AddProperty(config.NewProperty("UnkillableStepTimeout", 600))
+	conf.AddProperty(config.NewProperty("HealthCheckInterval", 60))
+	conf.AddProperty(config.NewProperty("HealthCheckNodeState", "ANY"))
+	conf.AddProperty(config.NewProperty("HealthCheckProgram", "/usr/bin/gpu_healthcheck.sh"))
+
 	extraConf := controller.Spec.ExtraConf
 	conf.AddProperty(config.NewPropertyRaw("#"))
 	conf.AddProperty(config.NewPropertyRaw("### EXTRA CONFIG ###"))

--- a/internal/builder/controller_config_test.go
+++ b/internal/builder/controller_config_test.go
@@ -159,6 +159,19 @@ func TestBuilder_BuildControllerConfig(t *testing.T) {
 
 			case got.Data[slurmConfFile] == "" && got.BinaryData[slurmConfFile] == nil:
 				t.Errorf("got.Data[%s] = %v", slurmConfFile, got.Data[slurmConfFile])
+
+			default:
+				slurmConf := got.Data[slurmConfFile]
+				for _, directive := range []string{
+					"UnkillableStepTimeout=600",
+					"HealthCheckInterval=60",
+					"HealthCheckNodeState=ANY",
+					"HealthCheckProgram=/usr/bin/gpu_healthcheck.sh",
+				} {
+					if !strings.Contains(slurmConf, directive) {
+						t.Errorf("slurm.conf missing system default %q", directive)
+					}
+				}
 			}
 		})
 	}

--- a/internal/builder/controller_config_test.go
+++ b/internal/builder/controller_config_test.go
@@ -167,6 +167,7 @@ func TestBuilder_BuildControllerConfig(t *testing.T) {
 					"HealthCheckInterval=60",
 					"HealthCheckNodeState=ANY",
 					"HealthCheckProgram=/usr/bin/gpu_healthcheck.sh",
+					"JobRequeue=0",
 				} {
 					if !strings.Contains(slurmConf, directive) {
 						t.Errorf("slurm.conf missing system default %q", directive)

--- a/internal/builder/controller_config_test.go
+++ b/internal/builder/controller_config_test.go
@@ -172,6 +172,11 @@ func TestBuilder_BuildControllerConfig(t *testing.T) {
 						t.Errorf("slurm.conf missing system default %q", directive)
 					}
 				}
+				if cgroupConf, ok := got.Data[cgroupConfFile]; ok {
+					if !strings.Contains(cgroupConf, "ConstrainRAMSpace=yes") {
+						t.Errorf("cgroup.conf missing ConstrainRAMSpace=yes")
+					}
+				}
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

Add system-critical Slurm defaults to the Slinky operator so every cluster (IC and BM) gets them automatically. These are infrastructure config in the same category as AuthType=auth/slurm.

## What is added

### slurm.conf (buildSlurmConf)

```
### SYSTEM DEFAULTS ###
UnkillableStepTimeout=600
HealthCheckInterval=60
HealthCheckNodeState=ANY
HealthCheckProgram=/usr/bin/gpu_healthcheck.sh
```

### cgroup.conf (buildCgroupConf)

```
ConstrainRAMSpace=yes
```

## Why

- **UnkillableStepTimeout=600**: Prevents "kill task failed" node drains (default 60s too short for GPU job teardown). FA had 20 nodes drain from this.
- **HealthCheckProgram**: Auto-resumes nodes drained for "kill task failed" if GPUs healthy.
- **ConstrainRAMSpace=yes**: Without this, --mem in sbatch is just a scheduling hint. Tangible confirmed --mem=500GB did not prevent OOM. With this, Slurm enforces memory limits via cgroups.
- **Covers IC and BM**: Both use the Slinky operator.
- **No annotation gate needed**: Slinky operator rebuilds slurm.conf natively.

## What is NOT hardcoded

- **MemSpecLimit**: Node-size-dependent. Set per-cluster via extraConf/UI.

## Requires

v1.0.7+ worker images for HealthCheckProgram (/usr/bin/gpu_healthcheck.sh must exist).

## QA verification (Apr 18)

Cluster jhu-test-slurm-default-configs on QA (t-c7f12d03). Operator image 1.0.3-tcl5588-test + worker v1.0.7-test.

| # | Test | Result |
|---|------|--------|
| 1 | slurm.conf has SYSTEM DEFAULTS with all 4 directives | PASS |
| 2 | cgroup.conf has ConstrainRAMSpace=yes | PASS |
| 3 | scontrol show config confirms all values active | PASS |
| 4 | Both partitions alive (slinky + all*), node idle | PASS |
| 5 | 17 SSSD packages installed on worker (no crash) | PASS |
| 6 | sssd_sudo responder running on worker | PASS |
| 7 | /usr/bin/gpu_healthcheck.sh exists with auto-undrain logic | PASS |
| 8 | nsswitch.conf has sudoers: files sss | PASS |
| 9 | Drain "kill task failed" -> auto-resumed within 60s | PASS |
| 10 | Drain "maintenance: BIOS upgrade" -> NOT resumed | PASS |

## Follow-up

After this ships in a new chart version, remove slurmHealthCheckConf() from the cluster operator buildSlurmExtraConf (currently duplicated via PR #472).

One-pager: https://www.notion.so/345b878aad1a81148a86c29cdb2c7d3b
Ticket: TCL-5588