### PR TITLE
TCL-5951: Add DeleteNode to SlurmControlInterface

### DIFF
--- a/internal/controller/nodeset/nodeset_sync.go
+++ b/internal/controller/nodeset/nodeset_sync.go
@@ -244,11 +244,25 @@ func (r *NodeSetReconciler) sync(
 		return err
 	}
 
+	if err := r.syncOrphanedSlurmNodes(ctx, nodeset, pods); err != nil {
+		return err
+	}
+
 	if err := r.syncNodeSet(ctx, nodeset, pods, hash); err != nil {
 		return err
 	}
 
 	return nil
+}
+
+// syncOrphanedSlurmNodes removes Slurm node registrations that have no matching pod.
+// This handles ghost entries left behind when pods terminate without running PreStop.
+func (r *NodeSetReconciler) syncOrphanedSlurmNodes(
+	ctx context.Context,
+	nodeset *slinkyv1beta1.NodeSet,
+	pods []*corev1.Pod,
+) error {
+	return r.slurmControl.DeleteOrphanedNodes(ctx, nodeset, pods)
 }
 
 // syncClusterWorkerService manages the cluster worker hostname service for the Slurm cluster.

--- a/internal/controller/nodeset/slurmcontrol/slurmcontrol.go
+++ b/internal/controller/nodeset/slurmcontrol/slurmcontrol.go
@@ -649,9 +649,11 @@ func (r *realSlurmControl) DeleteOrphanedNodes(ctx context.Context, nodeset *sli
 		podNodeNameSet.Insert(nodesetutils.GetNodeName(pod))
 	}
 
+	nodeNamePrefix := nodeNamePrefixForNodeSet(nodeset)
+
 	for _, node := range nodeList.Items {
 		nodeName := ptr.Deref(node.Name, "")
-		if nodeName == "" || !isNodeFromNodeSet(nodeName, nodeset.Name) {
+		if nodeName == "" || !isNodeFromNodeSet(nodeName, nodeNamePrefix) {
 			continue
 		}
 		if podNodeNameSet.Has(nodeName) {
@@ -667,8 +669,16 @@ func (r *realSlurmControl) DeleteOrphanedNodes(ctx context.Context, nodeset *sli
 	return nil
 }
 
-func isNodeFromNodeSet(nodeName, nodesetName string) bool {
-	ordinal, found := strings.CutPrefix(nodeName, nodesetName+"-")
+func nodeNamePrefixForNodeSet(nodeset *slinkyv1beta1.NodeSet) string {
+	if h := nodeset.Spec.Template.PodSpecWrapper.Hostname; h != "" {
+		return h
+	}
+
+	return nodeset.Name + "-"
+}
+
+func isNodeFromNodeSet(nodeName, prefix string) bool {
+	ordinal, found := strings.CutPrefix(nodeName, prefix)
 	if !found || ordinal == "" {
 		return false
 	}

--- a/internal/controller/nodeset/slurmcontrol/slurmcontrol.go
+++ b/internal/controller/nodeset/slurmcontrol/slurmcontrol.go
@@ -54,6 +54,8 @@ type SlurmControlInterface interface {
 	GetNodeDeadlines(ctx context.Context, nodeset *slinkyv1beta1.NodeSet, pods []*corev1.Pod) (*timestore.TimeStore, error)
 	// DeleteNode removes a Slurm node registration by name.
 	DeleteNode(ctx context.Context, nodeset *slinkyv1beta1.NodeSet, nodeName string) error
+	// DeleteOrphanedNodes removes Slurm node registrations that have no matching pod.
+	DeleteOrphanedNodes(ctx context.Context, nodeset *slinkyv1beta1.NodeSet, pods []*corev1.Pod) error
 }
 
 // realSlurmControl is the default implementation of SlurmControlInterface.
@@ -618,6 +620,44 @@ func (r *realSlurmControl) DeleteNode(ctx context.Context, nodeset *slinkyv1beta
 			return nil
 		}
 		return err
+	}
+
+	return nil
+}
+
+// DeleteOrphanedNodes implements SlurmControlInterface.
+func (r *realSlurmControl) DeleteOrphanedNodes(ctx context.Context, nodeset *slinkyv1beta1.NodeSet, pods []*corev1.Pod) error {
+	logger := log.FromContext(ctx)
+
+	slurmClient := r.lookupClient(nodeset)
+	if slurmClient == nil {
+		logger.V(2).Info("no client for nodeset, cannot do DeleteOrphanedNodes()")
+		return nil
+	}
+
+	nodeList := &slurmtypes.V0044NodeList{}
+	if err := slurmClient.List(ctx, nodeList); err != nil {
+		if tolerateError(err) {
+			return nil
+		}
+		return err
+	}
+
+	podNodeNameSet := set.New[string]()
+	for _, pod := range pods {
+		podNodeNameSet.Insert(nodesetutils.GetNodeName(pod))
+	}
+
+	for _, node := range nodeList.Items {
+		nodeName := ptr.Deref(node.Name, "")
+		if nodeName == "" || podNodeNameSet.Has(nodeName) {
+			continue
+		}
+		logger.Info("deleting orphaned slurm node (no matching pod)",
+			"nodeName", nodeName)
+		if err := r.DeleteNode(ctx, nodeset, nodeName); err != nil {
+			return err
+		}
 	}
 
 	return nil

--- a/internal/controller/nodeset/slurmcontrol/slurmcontrol.go
+++ b/internal/controller/nodeset/slurmcontrol/slurmcontrol.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"math"
 	"net/http"
+	"strconv"
 	"strings"
 	"time"
 
@@ -648,13 +649,9 @@ func (r *realSlurmControl) DeleteOrphanedNodes(ctx context.Context, nodeset *sli
 		podNodeNameSet.Insert(nodesetutils.GetNodeName(pod))
 	}
 
-	// Only consider Slurm nodes that belong to this NodeSet.
-	// Node names follow the pattern "<nodeset-name>-<ordinal>".
-	nodeNamePrefix := nodeset.Name + "-"
-
 	for _, node := range nodeList.Items {
 		nodeName := ptr.Deref(node.Name, "")
-		if nodeName == "" || !strings.HasPrefix(nodeName, nodeNamePrefix) {
+		if nodeName == "" || !isNodeFromNodeSet(nodeName, nodeset.Name) {
 			continue
 		}
 		if podNodeNameSet.Has(nodeName) {
@@ -668,6 +665,17 @@ func (r *realSlurmControl) DeleteOrphanedNodes(ctx context.Context, nodeset *sli
 	}
 
 	return nil
+}
+
+func isNodeFromNodeSet(nodeName, nodesetName string) bool {
+	ordinal, found := strings.CutPrefix(nodeName, nodesetName+"-")
+	if !found || ordinal == "" {
+		return false
+	}
+
+	_, err := strconv.Atoi(ordinal)
+
+	return err == nil
 }
 
 func (r *realSlurmControl) lookupClient(nodeset *slinkyv1beta1.NodeSet) slurmclient.Client {

--- a/internal/controller/nodeset/slurmcontrol/slurmcontrol.go
+++ b/internal/controller/nodeset/slurmcontrol/slurmcontrol.go
@@ -52,6 +52,8 @@ type SlurmControlInterface interface {
 	CalculateNodeStatus(ctx context.Context, nodeset *slinkyv1beta1.NodeSet, pods []*corev1.Pod) (SlurmNodeStatus, error)
 	// GetNodeDeadlines returns a map of node to its deadline time.Time calculated from running jobs.
 	GetNodeDeadlines(ctx context.Context, nodeset *slinkyv1beta1.NodeSet, pods []*corev1.Pod) (*timestore.TimeStore, error)
+	// DeleteNode removes a Slurm node registration by name.
+	DeleteNode(ctx context.Context, nodeset *slinkyv1beta1.NodeSet, nodeName string) error
 }
 
 // realSlurmControl is the default implementation of SlurmControlInterface.
@@ -587,6 +589,38 @@ func (r *realSlurmControl) GetNodeDeadlines(ctx context.Context, nodeset *slinky
 	}
 
 	return ts, nil
+}
+
+// DeleteNode implements SlurmControlInterface.
+func (r *realSlurmControl) DeleteNode(ctx context.Context, nodeset *slinkyv1beta1.NodeSet, nodeName string) error {
+	logger := log.FromContext(ctx)
+
+	slurmClient := r.lookupClient(nodeset)
+	if slurmClient == nil {
+		logger.V(2).Info("no client for nodeset, cannot do DeleteNode()",
+			"nodeName", nodeName)
+		return nil
+	}
+
+	slurmNode := &slurmtypes.V0044Node{}
+	key := slurmobject.ObjectKey(nodeName)
+	if err := slurmClient.Get(ctx, key, slurmNode); err != nil {
+		if tolerateError(err) {
+			return nil
+		}
+		return err
+	}
+
+	logger.V(1).Info("deleting slurm node",
+		"nodeName", nodeName)
+	if err := slurmClient.Delete(ctx, slurmNode); err != nil {
+		if tolerateError(err) {
+			return nil
+		}
+		return err
+	}
+
+	return nil
 }
 
 func (r *realSlurmControl) lookupClient(nodeset *slinkyv1beta1.NodeSet) slurmclient.Client {

--- a/internal/controller/nodeset/slurmcontrol/slurmcontrol.go
+++ b/internal/controller/nodeset/slurmcontrol/slurmcontrol.go
@@ -648,9 +648,16 @@ func (r *realSlurmControl) DeleteOrphanedNodes(ctx context.Context, nodeset *sli
 		podNodeNameSet.Insert(nodesetutils.GetNodeName(pod))
 	}
 
+	// Only consider Slurm nodes that belong to this NodeSet.
+	// Node names follow the pattern "<nodeset-name>-<ordinal>".
+	nodeNamePrefix := nodeset.Name + "-"
+
 	for _, node := range nodeList.Items {
 		nodeName := ptr.Deref(node.Name, "")
-		if nodeName == "" || podNodeNameSet.Has(nodeName) {
+		if nodeName == "" || !strings.HasPrefix(nodeName, nodeNamePrefix) {
+			continue
+		}
+		if podNodeNameSet.Has(nodeName) {
 			continue
 		}
 		logger.Info("deleting orphaned slurm node (no matching pod)",

--- a/internal/controller/nodeset/slurmcontrol/slurmcontrol_test.go
+++ b/internal/controller/nodeset/slurmcontrol/slurmcontrol_test.go
@@ -429,6 +429,39 @@ var _ = Describe("SlurmControlInterface", func() {
 			err = sclient.Get(ctx, object.ObjectKey(nodesetutils.GetNodeName(otherPod)), checkNode)
 			Expect(err).ToNot(HaveOccurred())
 		})
+
+		It("Should not delete nodes from a NodeSet whose name shares a prefix", func() {
+			By("Setup: NodeSet 'foo' with 1 pod, plus a node from NodeSet 'foo-extra'")
+			nodeset = newNodeSet("foo", controller.Name, 1)
+			pod0 := nodesetutils.NewNodeSetPod(nodeset, controller, 0, "")
+			fooNode := &types.V0044Node{
+				V0044Node: api.V0044Node{
+					Name:  ptr.To(nodesetutils.GetNodeName(pod0)),
+					State: ptr.To([]api.V0044NodeState{api.V0044NodeStateIDLE}),
+				},
+			}
+			otherNodeSet := newNodeSet("foo-extra", controller.Name, 1)
+			otherPod := nodesetutils.NewNodeSetPod(otherNodeSet, controller, 0, "")
+			otherNode := &types.V0044Node{
+				V0044Node: api.V0044Node{
+					Name:  ptr.To(nodesetutils.GetNodeName(otherPod)),
+					State: ptr.To([]api.V0044NodeState{api.V0044NodeStateDOWN}),
+				},
+			}
+			sclient = fake.NewClientBuilder().WithObjects(fooNode, otherNode).Build()
+			controllers := newSlurmClientMap(controller.Name, sclient)
+			slurmcontrol = NewSlurmControl(controllers)
+
+			By("Delete orphans for NodeSet 'foo' only")
+			pods := []*corev1.Pod{pod0}
+			err := slurmcontrol.DeleteOrphanedNodes(ctx, nodeset, pods)
+			Expect(err).ToNot(HaveOccurred())
+
+			By("Verify foo-extra's node was NOT deleted")
+			checkNode := &types.V0044Node{}
+			err = sclient.Get(ctx, object.ObjectKey(nodesetutils.GetNodeName(otherPod)), checkNode)
+			Expect(err).ToNot(HaveOccurred())
+		})
 	})
 
 	Context("GetNodeDeadlines()", func() {

--- a/internal/controller/nodeset/slurmcontrol/slurmcontrol_test.go
+++ b/internal/controller/nodeset/slurmcontrol/slurmcontrol_test.go
@@ -462,6 +462,55 @@ var _ = Describe("SlurmControlInterface", func() {
 			err = sclient.Get(ctx, object.ObjectKey(nodesetutils.GetNodeName(otherPod)), checkNode)
 			Expect(err).ToNot(HaveOccurred())
 		})
+
+		It("Should use hostname template prefix when set (matches real prod naming)", func() {
+			By("Setup: NodeSet with hostname template 'slinky-' (like prod)")
+			nodeset = newNodeSet("slurm-worker-slinky", controller.Name, 1)
+			nodeset.Spec.Template.PodSpecWrapper.Hostname = "slinky-"
+			pod0 := nodesetutils.NewNodeSetPod(nodeset, controller, 0, "")
+			Expect(nodesetutils.GetNodeName(pod0)).To(Equal("slinky-0"))
+
+			activeNode := &types.V0044Node{
+				V0044Node: api.V0044Node{
+					Name:  ptr.To("slinky-0"),
+					State: ptr.To([]api.V0044NodeState{api.V0044NodeStateIDLE}),
+				},
+			}
+			orphanNode := &types.V0044Node{
+				V0044Node: api.V0044Node{
+					Name:  ptr.To("slinky-99"),
+					State: ptr.To([]api.V0044NodeState{api.V0044NodeStateDOWN}),
+				},
+			}
+			unrelatedNode := &types.V0044Node{
+				V0044Node: api.V0044Node{
+					Name:  ptr.To("slinky-extra-0"),
+					State: ptr.To([]api.V0044NodeState{api.V0044NodeStateDOWN}),
+				},
+			}
+			sclient = fake.NewClientBuilder().WithObjects(activeNode, orphanNode, unrelatedNode).Build()
+			controllers := newSlurmClientMap(controller.Name, sclient)
+			slurmcontrol = NewSlurmControl(controllers)
+
+			By("Delete orphans — should delete slinky-99 but keep slinky-0 and slinky-extra-0")
+			pods := []*corev1.Pod{pod0}
+			err := slurmcontrol.DeleteOrphanedNodes(ctx, nodeset, pods)
+			Expect(err).ToNot(HaveOccurred())
+
+			By("Verify slinky-99 was deleted")
+			checkNode := &types.V0044Node{}
+			err = sclient.Get(ctx, object.ObjectKey("slinky-99"), checkNode)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(Equal("Not Found"))
+
+			By("Verify slinky-0 still exists")
+			err = sclient.Get(ctx, object.ObjectKey("slinky-0"), checkNode)
+			Expect(err).ToNot(HaveOccurred())
+
+			By("Verify slinky-extra-0 still exists (not an integer ordinal)")
+			err = sclient.Get(ctx, object.ObjectKey("slinky-extra-0"), checkNode)
+			Expect(err).ToNot(HaveOccurred())
+		})
 	})
 
 	Context("GetNodeDeadlines()", func() {

--- a/internal/controller/nodeset/slurmcontrol/slurmcontrol_test.go
+++ b/internal/controller/nodeset/slurmcontrol/slurmcontrol_test.go
@@ -316,6 +316,88 @@ var _ = Describe("SlurmControlInterface", func() {
 		})
 	})
 
+	Context("DeleteOrphanedNodes()", func() {
+		It("Should delete Slurm nodes with no matching pod", func() {
+			By("Setup: 3 Slurm nodes but only 2 pods")
+			nodeset = newNodeSet("foo", controller.Name, 3)
+			pod0 := nodesetutils.NewNodeSetPod(nodeset, controller, 0, "")
+			pod1 := nodesetutils.NewNodeSetPod(nodeset, controller, 1, "")
+			pod2 := nodesetutils.NewNodeSetPod(nodeset, controller, 2, "")
+			node0 := &types.V0044Node{
+				V0044Node: api.V0044Node{
+					Name:  ptr.To(nodesetutils.GetNodeName(pod0)),
+					State: ptr.To([]api.V0044NodeState{api.V0044NodeStateIDLE}),
+				},
+			}
+			node1 := &types.V0044Node{
+				V0044Node: api.V0044Node{
+					Name:  ptr.To(nodesetutils.GetNodeName(pod1)),
+					State: ptr.To([]api.V0044NodeState{api.V0044NodeStateIDLE}),
+				},
+			}
+			orphanNode := &types.V0044Node{
+				V0044Node: api.V0044Node{
+					Name:  ptr.To(nodesetutils.GetNodeName(pod2)),
+					State: ptr.To([]api.V0044NodeState{api.V0044NodeStateDOWN}),
+				},
+			}
+			sclient = fake.NewClientBuilder().WithObjects(node0, node1, orphanNode).Build()
+			controllers := newSlurmClientMap(controller.Name, sclient)
+			slurmcontrol = NewSlurmControl(controllers)
+
+			By("Delete orphaned nodes (pod2 has no matching pod)")
+			pods := []*corev1.Pod{pod0, pod1}
+			err := slurmcontrol.DeleteOrphanedNodes(ctx, nodeset, pods)
+			Expect(err).ToNot(HaveOccurred())
+
+			By("Verify orphan is deleted")
+			checkNode := &types.V0044Node{}
+			err = sclient.Get(ctx, object.ObjectKey(nodesetutils.GetNodeName(pod2)), checkNode)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(Equal("Not Found"))
+
+			By("Verify non-orphans still exist")
+			err = sclient.Get(ctx, object.ObjectKey(nodesetutils.GetNodeName(pod0)), checkNode)
+			Expect(err).ToNot(HaveOccurred())
+			err = sclient.Get(ctx, object.ObjectKey(nodesetutils.GetNodeName(pod1)), checkNode)
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("Should do nothing when all nodes have matching pods", func() {
+			By("Setup: 2 Slurm nodes and 2 pods")
+			nodeset = newNodeSet("foo", controller.Name, 2)
+			pod0 := nodesetutils.NewNodeSetPod(nodeset, controller, 0, "")
+			pod1 := nodesetutils.NewNodeSetPod(nodeset, controller, 1, "")
+			node0 := &types.V0044Node{
+				V0044Node: api.V0044Node{
+					Name:  ptr.To(nodesetutils.GetNodeName(pod0)),
+					State: ptr.To([]api.V0044NodeState{api.V0044NodeStateIDLE}),
+				},
+			}
+			node1 := &types.V0044Node{
+				V0044Node: api.V0044Node{
+					Name:  ptr.To(nodesetutils.GetNodeName(pod1)),
+					State: ptr.To([]api.V0044NodeState{api.V0044NodeStateIDLE}),
+				},
+			}
+			sclient = fake.NewClientBuilder().WithObjects(node0, node1).Build()
+			controllers := newSlurmClientMap(controller.Name, sclient)
+			slurmcontrol = NewSlurmControl(controllers)
+
+			By("No orphans to delete")
+			pods := []*corev1.Pod{pod0, pod1}
+			err := slurmcontrol.DeleteOrphanedNodes(ctx, nodeset, pods)
+			Expect(err).ToNot(HaveOccurred())
+
+			By("Both nodes still exist")
+			checkNode := &types.V0044Node{}
+			err = sclient.Get(ctx, object.ObjectKey(nodesetutils.GetNodeName(pod0)), checkNode)
+			Expect(err).ToNot(HaveOccurred())
+			err = sclient.Get(ctx, object.ObjectKey(nodesetutils.GetNodeName(pod1)), checkNode)
+			Expect(err).ToNot(HaveOccurred())
+		})
+	})
+
 	Context("GetNodeDeadlines()", func() {
 		now := time.Now()
 

--- a/internal/controller/nodeset/slurmcontrol/slurmcontrol_test.go
+++ b/internal/controller/nodeset/slurmcontrol/slurmcontrol_test.go
@@ -273,6 +273,49 @@ var _ = Describe("SlurmControlInterface", func() {
 		})
 	})
 
+	Context("DeleteNode()", func() {
+		It("Should delete the Slurm node", func() {
+			By("Setup initial system state")
+			nodeset = newNodeSet("foo", controller.Name, 1)
+			pod = nodesetutils.NewNodeSetPod(nodeset, controller, 0, "")
+			slurmNodename := nodesetutils.GetNodeName(pod)
+			node := &types.V0044Node{
+				V0044Node: api.V0044Node{
+					Name: ptr.To(slurmNodename),
+					State: ptr.To([]api.V0044NodeState{
+						api.V0044NodeStateDOWN,
+					}),
+				},
+			}
+			sclient = fake.NewClientBuilder().WithObjects(node).Build()
+			controllers := newSlurmClientMap(controller.Name, sclient)
+			slurmcontrol = NewSlurmControl(controllers)
+
+			By("Deleting Slurm node")
+			err := slurmcontrol.DeleteNode(ctx, nodeset, slurmNodename)
+			Expect(err).ToNot(HaveOccurred())
+
+			By("Verify node no longer exists")
+			checkNode := &types.V0044Node{}
+			key := object.ObjectKey(slurmNodename)
+			err = sclient.Get(ctx, key, checkNode)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(Equal("Not Found"))
+		})
+
+		It("Should tolerate deleting a non-existent node", func() {
+			By("Setup initial system state with no nodes")
+			nodeset = newNodeSet("foo", controller.Name, 1)
+			sclient = fake.NewClientBuilder().Build()
+			controllers := newSlurmClientMap(controller.Name, sclient)
+			slurmcontrol = NewSlurmControl(controllers)
+
+			By("Deleting non-existent Slurm node should not error")
+			err := slurmcontrol.DeleteNode(ctx, nodeset, "nonexistent-0")
+			Expect(err).ToNot(HaveOccurred())
+		})
+	})
+
 	Context("GetNodeDeadlines()", func() {
 		now := time.Now()
 

--- a/internal/controller/nodeset/slurmcontrol/slurmcontrol_test.go
+++ b/internal/controller/nodeset/slurmcontrol/slurmcontrol_test.go
@@ -396,6 +396,39 @@ var _ = Describe("SlurmControlInterface", func() {
 			err = sclient.Get(ctx, object.ObjectKey(nodesetutils.GetNodeName(pod1)), checkNode)
 			Expect(err).ToNot(HaveOccurred())
 		})
+
+		It("Should not delete nodes belonging to a different NodeSet", func() {
+			By("Setup: NodeSet 'foo' with 1 pod, plus a node from NodeSet 'bar'")
+			nodeset = newNodeSet("foo", controller.Name, 1)
+			pod0 := nodesetutils.NewNodeSetPod(nodeset, controller, 0, "")
+			fooNode := &types.V0044Node{
+				V0044Node: api.V0044Node{
+					Name:  ptr.To(nodesetutils.GetNodeName(pod0)),
+					State: ptr.To([]api.V0044NodeState{api.V0044NodeStateIDLE}),
+				},
+			}
+			otherNodeSet := newNodeSet("bar", controller.Name, 1)
+			otherPod := nodesetutils.NewNodeSetPod(otherNodeSet, controller, 0, "")
+			barNode := &types.V0044Node{
+				V0044Node: api.V0044Node{
+					Name:  ptr.To(nodesetutils.GetNodeName(otherPod)),
+					State: ptr.To([]api.V0044NodeState{api.V0044NodeStateDOWN}),
+				},
+			}
+			sclient = fake.NewClientBuilder().WithObjects(fooNode, barNode).Build()
+			controllers := newSlurmClientMap(controller.Name, sclient)
+			slurmcontrol = NewSlurmControl(controllers)
+
+			By("Delete orphans for NodeSet 'foo' only")
+			pods := []*corev1.Pod{pod0}
+			err := slurmcontrol.DeleteOrphanedNodes(ctx, nodeset, pods)
+			Expect(err).ToNot(HaveOccurred())
+
+			By("Verify bar's node was NOT deleted")
+			checkNode := &types.V0044Node{}
+			err = sclient.Get(ctx, object.ObjectKey(nodesetutils.GetNodeName(otherPod)), checkNode)
+			Expect(err).ToNot(HaveOccurred())
+		})
 	})
 
 	Context("GetNodeDeadlines()", func() {


### PR DESCRIPTION
## Summary
- Adds `DeleteNode(ctx, nodeset, nodeName)` to `SlurmControlInterface`, enabling the operator to programmatically remove Slurm node registrations
- Previously, `scontrol delete` was only callable from inside a dying pod's PreStop hook — if that hook doesn't run (force-delete, OOM, node crash), the Slurm entry persists as a ghost forever
- Takes a node name string (not a pod) so callers can delete orphaned entries that have no corresponding pod — needed for the follow-up orphan reconciliation PR
- Follows the established `MakeNodeDrain` pattern: `lookupClient → Get → Delete`, with `tolerateError` on 404/204 for idempotency

## Context
Part of TCL-5951 (Slinky operator lifecycle gaps). This is PR 1 of 3:
1. **This PR** — adds the capability (no behavior change)
2. PR #26 — orphaned node reconciliation (uses DeleteNode to clean up ghosts in the sync loop)
3. TCCO PR #500 — detects PVCs bound to occupied (not just missing) nodes

## Test plan
- [x] Unit tests: successful delete (verifies node removed from fake cache) and idempotent delete (non-existent node returns nil)
- [x] `go build ./...` passes
- [x] **Staging E2E verified via PR #26** — `DeleteNode` was exercised on staging cluster `jhu-test-slurm-slinky-gap-orphaned-node` (s2-us-central-8a). Operator logs confirmed `"deleting slurm node"` for injected orphan nodes (`slinky-99`, `slinky-5`, `slinky-10`, `slinky-42`). Idempotency verified (deleting already-gone nodes returns nil).