### PR TITLE
[TCL-6165] feat: add --namespace flag for namespace-scoped manager

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -18,6 +18,7 @@ import (
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
@@ -55,6 +56,7 @@ type Flags struct {
 	metricsAddr          string
 	secureMetrics        bool
 	enableHTTP2          bool
+	namespace            string
 }
 
 func parseFlags(flags *Flags) {
@@ -81,6 +83,9 @@ func parseFlags(flags *Flags) {
 		"If set the metrics endpoint is served securely")
 	flag.BoolVar(&flags.enableHTTP2, "enable-http2", false,
 		"If set, HTTP/2 will be enabled for the metrics and webhook servers")
+	flag.StringVar(&flags.namespace, "namespace", "",
+		"If set, the operator only watches Slinky resources in this namespace. "+
+			"Empty (the default) watches all namespaces.")
 	flag.Parse()
 }
 
@@ -107,7 +112,9 @@ func main() {
 		tlsOpts = append(tlsOpts, disableHTTP2)
 	}
 
-	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
+	leaderElectionID := "0033bda7.slinky.slurm.net"
+
+	mgrOpts := ctrl.Options{
 		Scheme: scheme,
 		Metrics: server.Options{
 			TLSOpts:     tlsOpts,
@@ -115,9 +122,19 @@ func main() {
 		},
 		HealthProbeBindAddress:        flags.probeAddr,
 		LeaderElection:                flags.enableLeaderElection,
-		LeaderElectionID:              "0033bda7.slinky.slurm.net",
+		LeaderElectionID:              leaderElectionID,
 		LeaderElectionReleaseOnCancel: true,
-	})
+	}
+
+	// Restrict informers to a single namespace and give the leader-election
+	// lock a unique name so multiple operator instances can coexist on the
+	// same cluster without racing over the same CRs.
+	if flags.namespace != "" {
+		mgrOpts.Cache.DefaultNamespaces = map[string]cache.Config{flags.namespace: {}}
+		mgrOpts.LeaderElectionID = leaderElectionID + "." + flags.namespace
+	}
+
+	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), mgrOpts)
 	if err != nil {
 		setupLog.Error(err, "unable to start manager")
 		os.Exit(1)


### PR DESCRIPTION
When `--namespace=<ns>` is set on the operator command line, the controller-runtime manager watches only that namespace (`cache.Options.DefaultNamespaces`) and the leader-election ID is suffixed with the namespace so multiple operator instances on the same cluster do not share a lease.

Enables running one slurm-operator per tenant namespace on the substrate, which is needed for per-cluster substrate-managed slurm control planes (cluster-operator side: incoming PRs that build `Controller` / `Accounting` CRs in each cluster namespace).

Default behavior (empty flag) is unchanged: cluster-wide watch with the original `0033bda7.slinky.slurm.net` leader-election ID. Existing deployments do not need to change.

## Test plan

- [x] `go vet ./cmd/manager/...` — clean.
- [ ] Build a new image, deploy with `--namespace=foo`, confirm the operator only reconciles CRs in `foo` and ignores CRs in other namespaces.
- [ ] Run two instances with different `--namespace` values in different namespaces, confirm both reconcile their own CRs without leader-election contention.

Linear: TCL-6165